### PR TITLE
Workaround for broken floating windows

### DIFF
--- a/radiant/mainframe.cpp
+++ b/radiant/mainframe.cpp
@@ -2021,8 +2021,10 @@ static void mainframe_unmap( GtkWidget *widget ){
 
 static GtkWidget* create_floating( MainFrame* mainframe ){
 	GtkWidget *wnd = gtk_window_new( GTK_WINDOW_TOPLEVEL );
-	//if (mainframe->CurrentStyle() != MainFrame::eFloating)
-	gtk_window_set_transient_for( GTK_WINDOW( wnd ), GTK_WINDOW( mainframe->m_pWidget ) );
+	//workaround for a bug with set_transient_for in GTK - resulting behaviour is not perfect but better than the bug.
+	//(see https://bugzilla.gnome.org/show_bug.cgi?id=658975 regarding the bug)
+	if (mainframe->CurrentStyle() != MainFrame::eFloating)
+		gtk_window_set_transient_for( GTK_WINDOW( wnd ), GTK_WINDOW( mainframe->m_pWidget ) );
 	gtk_widget_set_events( wnd, GDK_KEY_PRESS_MASK | GDK_KEY_RELEASE_MASK );
 	gtk_signal_connect( GTK_OBJECT( wnd ), "delete_event", GTK_SIGNAL_FUNC( widget_delete_hide ), NULL );
 	gtk_signal_connect( GTK_OBJECT( wnd ), "destroy", GTK_SIGNAL_FUNC( gtk_widget_destroy ), NULL );


### PR DESCRIPTION
Using the Floating Window Layout on Windows, the XY Window, Camera an other windows created via create_floating() are always in front of e.g. the surface inspector and the preferences.

This is due to a bug in GTK, see https://bugzilla.gnome.org/show_bug.cgi?id=658975

This fix disables the transient behaviour for floating windows - this means they're no longer in front of the main window (bad) but also not in front of other ones (good). So the user has to resize/move the main window accordingly, but in my opinion that's preferable to the bug.

A better solution might be to make all windows (i.e. surface inspector, preferences etc.) transient for the main window, but that's easier said than done because e.g. the surface inspector is from a plugin that doesn't have access to the main window as it is. (Would require changes to the plugin interface.)
