### PR TITLE
Add support for W:ET to the game setup dialog

### DIFF
--- a/config.py
+++ b/config.py
@@ -33,7 +33,7 @@ class Config:
 		# platforms for which to assemble a setup
 		self.setup_platforms = [ 'local', 'x86', 'x64', 'win32' ]
 		# paks to assemble in the setup
-		self.setup_packs = [ 'Q3Pack', 'UrTPack', ] # 'UFOAIPack', 'Q2WPack', 'ReactionPack' ]
+		self.setup_packs = [ 'Q3Pack', 'UrTPack', 'ETPack', ] # 'UFOAIPack', 'Q2WPack', 'ReactionPack' ]
 
 	def __repr__( self ):
 		return 'config: target=%s config=%s' % ( self.target_selected, self.config_selected )

--- a/radiant/preferences.cpp
+++ b/radiant/preferences.cpp
@@ -3335,6 +3335,9 @@ void CGameInstall::BuildDialog() {
 		case GAME_REACTION:
 			gtk_combo_box_append_text( GTK_COMBO_BOX( combo ), _( "Reaction Quake 3" ) );
 			break;
+		case GAME_ET:
+			gtk_combo_box_append_text( GTK_COMBO_BOX( combo ), _( "Wolfenstein: Enemy Territory" ) );
+			break;
 		}
 		iGame++;
 	}
@@ -3442,6 +3445,9 @@ void CGameInstall::Run() {
 		break;
 	case GAME_REACTION:
 		gameFilePath += "reaction.game";
+		break;
+	case GAME_ET:
+		gameFilePath += "et.game";
 		break;
 	}
 
@@ -3584,6 +3590,29 @@ void CGameInstall::Run() {
 		// for a specific game.
 		break;
 	}
+	case GAME_ET: {
+#ifdef _WIN32
+		fprintf( fg, "  "ENGINE_ATTRIBUTE "=\"ET.exe\"\n");
+#elif __linux__
+		fprintf( fg, "  "ENGINE_ATTRIBUTE "=\"et\"\n" );
+#endif
+		fprintf( fg, "  "TOOLS_ATTRIBUTE "=\"%sinstalls/"ET_PACK "/game\"\n", g_strAppPath.GetBuffer() );
+		fprintf( fg, "  prefix=\".etwolf\"\n" );
+		Str source = g_strAppPath.GetBuffer();
+		source += "installs/";
+		source += ET_PACK;
+		source += "/install/";
+		Str dest = m_strEngine.GetBuffer();
+		CopyTree( source.GetBuffer(), dest.GetBuffer() );
+		// Hardcoded fix for "missing" shaderlist in gamepack
+		dest += "/etmain/scripts/shaderlist.txt";
+		if(CheckFile(dest.GetBuffer()) != PATH_FILE) {
+			source += "etmain/scripts/default_shaderlist.txt";
+			radCopyFile(source.GetBuffer(),dest.GetBuffer());
+		}
+		fprintf( fg, "  basegame=\"etmain\"\n" );
+		break;
+	}
 	}
 	fprintf( fg, "/>\n" );
 	fclose( fg );
@@ -3632,6 +3661,9 @@ void CGameInstall::ScanGames() {
 		}
 		if ( stricmp( dirname, REACTION_PACK ) == 0 ) {
 			m_availGames[ iGame++ ] = GAME_REACTION;
+		}
+		if ( stricmp( dirname, ET_PACK ) == 0 ) {
+			m_availGames[ iGame++ ] = GAME_ET;
 		}
 	}
 	Sys_Printf( "No installable games found in: %s\n",

--- a/radiant/preferences.h
+++ b/radiant/preferences.h
@@ -213,6 +213,7 @@ void Dump();
 #define TREMULOUS_PACK "TremulousPack"
 #define JA_PACK "JAPack"
 #define REACTION_PACK "ReactionPack"
+#define ET_PACK "ETPack"
 
 class CGameInstall : public Dialog {
 public:
@@ -236,6 +237,7 @@ enum gameType_e {
 	GAME_TREMULOUS,
 	GAME_JA,
 	GAME_REACTION,
+	GAME_ET,
 	GAME_COUNT
 };
 


### PR DESCRIPTION
This adds support for Wolfenstein: Enemey - Territory back to the setup dialog.
Since the gamepack in the svn trunk is for radiant 1.5 this obviously has to be updated in order to get everything working.

A quick test unvailed no issues with the gamepack, compiling, running the engine, entitites, setup, ... works.

I've prepared a gamepack that works here http://merlin1991.at/~christian/zeroradiant/ETPack.7z

I suggest moving the current gamepack inside trunk into a 1.5 branch and adding the content of the archive instead.
