### PR TITLE
Fixed radiant not compiling after qboolean "wonkyness" decrease

### DIFF
--- a/include/iundo.h
+++ b/include/iundo.h
@@ -41,7 +41,7 @@ typedef void ( *PFN_UNDOADDENTITY )( entity_t *entity );
 //end an entity after the operation is performed
 typedef void ( *PFN_UNDOENDENTITY )( entity_t *entity );
 //undo last operation (bSilent == true -> will not print the "undone blah blah message")
-typedef void ( *PFN_UNDO )( unsigned char bSilent );
+typedef void ( *PFN_UNDO )( qboolean bSilent );
 //redo last undone operation
 typedef void ( *PFN_REDO )( void );
 //get the undo Id of the next undo (0 if none available)


### PR DESCRIPTION
A function pointer signature was using unsigned char instead of qboolean, which caused trouble when qboolean's type changed. (It wouldn't compile anymore.)
