### PR TITLE
Fixed wrong shaderpath and lack of shaderlist.txt for Jedi Academy

### DIFF
--- a/radiant/preferences.cpp
+++ b/radiant/preferences.cpp
@@ -3571,13 +3571,13 @@ void CGameInstall::Run() {
 		source += JA_PACK;
 		source += "/install/";
 		Str dest = m_strEngine.GetBuffer();
+		radCopyTree( source.GetBuffer(), dest.GetBuffer() );
 		// Hardcoded fix for "missing" shaderlist in gamepack
-		dest += "/baseq3/shaders/shaderlist.txt";
+		dest += "/base/shaders/shaderlist.txt";
 		if(CheckFile(dest.GetBuffer()) != PATH_FILE) {
-			source += "baseq3/shaders/default_shaderlist.txt";
+			source += "base/scripts/default_shaderlist.txt";
 			radCopyFile(source.GetBuffer(),dest.GetBuffer());
 		}
-		radCopyTree( source.GetBuffer(), dest.GetBuffer() );
 		fprintf( fg, "  basegame=\"base\"\n" );
 		fprintf( fg, "  shaderpath=\"shaders\"\n" );
 		fprintf( fg, "  default_scale=\"0.25\"\n" );


### PR DESCRIPTION
Some settings in ja.game, e.g. the setting to make the Radiant use shaders/ instead of scripts/ as the shader folder, were missing and the default_shaderlist.txt was not copied to shaderlist.txt if the latter did not exist already. I fixed that.

(Related to issue #44)
