### PR TITLE
Remove includes of glib/gconvert.h and glib/gmem.h; only include toplevel glib.h

### DIFF
--- a/tools/quake3/common/inout.c
+++ b/tools/quake3/common/inout.c
@@ -44,8 +44,6 @@
 
 // utf8 conversion
 #include <glib.h>
-#include <glib/gconvert.h>
-#include <glib/gmem.h>
 
 #ifdef WIN32
 HWND hwndOut = NULL;


### PR DESCRIPTION
Remove includes for glib/gconvert.h and glib/gmem.h, according to http://developer.gnome.org/glib/stable/glib-compiling.html it is an error to include individual glib headers starting with glib 2.32 (other than a few special cases.)
