### PR TITLE
Linking fix in Linux

### DIFF
--- a/config.py
+++ b/config.py
@@ -214,7 +214,7 @@ class Config:
             print 'xml2-config failed'
             assert( False )
         xml2libs = commands.getoutput( 'xml2-config --libs' )
-        env.Append( LINKFLAGS = xml2libs.split( ' ' ) )
+        env.ParseConfig( 'xml2-config --libs' )
         baseflags = [ '-pipe', '-Wall', '-fmessage-length=0', '-fvisibility=hidden', xml2.split( ' ' ) ]
 
         if ( useGtk ):
@@ -392,26 +392,28 @@ class Config:
                 ]:
                 shutil.copy( os.path.join( srcdir, x64_dll ), 'install/x64' )
 
-        def FinishBuild( self, target, source, env ):
-            print( 'Lookup and bundle the PNG and JPEG libraries' )
-            # radiant.bin doesn't link to jpeg lib directly, grab that from a module
-            # Python 2.7 only!
-            #module_ldd = subprocess.check_output( 'ldd -r install/modules/image.so', shell = True )
-            p = subprocess.Popen( 'ldd -r install/modules/image.so', shell = True, stdout = subprocess.PIPE )
-            module_ldd = p.communicate()[0]
+    def FinishBuild( self, target, source, env ):
+        print( 'Lookup and bundle the PNG and JPEG libraries' )
+        # radiant.bin doesn't link to jpeg lib directly, grab that from a module
+        # Python 2.7 only!
+        #module_ldd = subprocess.check_output( 'ldd -r install/modules/image.so', shell = True )
+        p = subprocess.Popen( 'ldd -r install/modules/image.so', shell = True, stdout = subprocess.PIPE )
+        module_ldd = p.communicate()[0]
 #                print( module_ldd )
 
-            def find_library( output, libname ):
-                match = filter( lambda l : l.find( libname ) != -1, output.split( '\n' ) )[0]
-                return re.split( '.*=> (.*) .*', match )[1]
+        def find_library( output, libname ):
+            print output
+            print libname
+            match = filter( lambda l : l.find( libname ) != -1, output.split( '\n' ) )[0]
+            return re.split( '.*=> (.*) .*', match )[1]
 
-            jpeg_path = find_library( module_ldd, 'libjpeg' )
-            print( 'JPEG library: %s' % repr( jpeg_path ) )
-            png_path = find_library( module_ldd, 'libpng' )
-            print( 'PNG  library: %s' % repr( png_path ) )
+        jpeg_path = find_library( module_ldd, 'libjpeg' )
+        print( 'JPEG library: %s' % repr( jpeg_path ) )
+        png_path = find_library( module_ldd, 'libpng' )
+        print( 'PNG  library: %s' % repr( png_path ) )
 
-            shutil.copy( jpeg_path, 'install' )
-            shutil.copy( png_path, 'install' )
+        shutil.copy( jpeg_path, 'install' )
+        shutil.copy( png_path, 'install' )
 
 # parse the config statement line to produce/update an existing config list
 # the configs expose a list of keywords and accepted values, which the engine parses out


### PR DESCRIPTION
There is an undefined reference error in Linux (ubuntu raring, gcc-4.7, ld 2.23.2), due to a bad argument order.

Libraries should be in the right order in the command line in order to be able to link them properly [1]. 

In our case, libxml was appended to LINKFLAGS instead of parsed like the rest of the libraries (and therefore appended **after** the compiled objects), causing multiple "undefined reference to" errors.

On the other hand, I could not find FinishBuild method due to bad indentation (it was nested too much). I have fixed this error, although I don't understand why libpng and libjpeg should be bundled.

Any comment or suggestion will be appreciated.

[1] http://stackoverflow.com/questions/45135/linker-order-gcc
