### PR TITLE
Use clang on OS X instead of gcc48

### DIFF
--- a/apple/README.md
+++ b/apple/README.md
@@ -14,7 +14,7 @@ Directions for OSX Mavericks 10.9 - your mileage may vary:
 - Install dependencies with MacPorts:
 
 ```
-sudo port install dylibbundler gcc48 gtkglext scons
+sudo port install dylibbundler pkgconfig gtkglext scons
 ```
 
 - Get the GtkRadiant code and compile:
@@ -22,7 +22,7 @@ sudo port install dylibbundler gcc48 gtkglext scons
 ```
 git clone https://github.com/TTimo/GtkRadiant.git
 cd GtkRadiant/
-scons cc=gcc-mp-4.8 cxx=g++-mp-4.8
+scons
 ```
 
 - Run the build:

--- a/contrib/prtview/AboutDialog.cpp
+++ b/contrib/prtview/AboutDialog.cpp
@@ -40,7 +40,7 @@ static void dialog_button_callback( GtkWidget *widget, gpointer data ){
 	ret = (int*)g_object_get_data( G_OBJECT( parent ), "ret" );
 
 	*loop = 0;
-	*ret = (int)data;
+	*ret = (int)((intptr_t)data);
 }
 
 static gint dialog_delete_callback( GtkWidget *widget, GdkEvent* event, gpointer data ){

--- a/contrib/prtview/ConfigDialog.cpp
+++ b/contrib/prtview/ConfigDialog.cpp
@@ -42,7 +42,7 @@ static void dialog_button_callback( GtkWidget *widget, gpointer data ){
 	ret = (int*)g_object_get_data( G_OBJECT( parent ), "ret" );
 
 	*loop = 0;
-	*ret = (int)data;
+	*ret = (int)((intptr_t)data);
 }
 
 static gint dialog_delete_callback( GtkWidget *widget, GdkEvent* event, gpointer data ){

--- a/contrib/prtview/gtkdlgs.cpp
+++ b/contrib/prtview/gtkdlgs.cpp
@@ -36,7 +36,7 @@ static void dialog_button_callback( GtkWidget *widget, gpointer data ){
 	ret = (int*)g_object_get_data( G_OBJECT( parent ), "ret" );
 
 	*loop = 0;
-	*ret = (int)data;
+	*ret = (int)((intptr_t)data);
 }
 
 static gint dialog_delete_callback( GtkWidget *widget, GdkEvent* event, gpointer data ){
@@ -59,7 +59,7 @@ static void file_sel_callback( GtkWidget *widget, gpointer data ){
 	filename = (char**)g_object_get_data( G_OBJECT( parent ), "filename" );
 
 	*loop = 0;
-	if ( (int)data == IDOK ) {
+	if ( (int)((intptr_t)data) == IDOK ) {
 		*filename = g_strdup( gtk_file_selection_get_filename( GTK_FILE_SELECTION( parent ) ) );
 	}
 }

--- a/contrib/prtview/stdafx.h
+++ b/contrib/prtview/stdafx.h
@@ -21,6 +21,7 @@
 #define __PRTVIEW_AFX_H__
 
 #include <gtk/gtk.h>
+#include <stdint.h>
 
 #if defined( __linux__ ) || defined( __APPLE__ )
 #include <GL/glx.h>


### PR DESCRIPTION
This is just to avoid having to install an extra dependency (IIRC gcc takes a while to build). I tested this on OS X 10.9.1, and both the ./install/radiant.bin and the .app bundle produced by apple/Makefile seem to work.

Also - add 'pkgconfig' to the list of MacPorts to install, as it's a required dependency.
