### PR TITLE
Fix "My Games" folder on Wintoons.

### DIFF
--- a/radiant/preferences.cpp
+++ b/radiant/preferences.cpp
@@ -1321,7 +1321,7 @@ void CGameDialog::Init(){
 		g_qeglobals.m_strHomeGame += "/";
 #elif defined ( _WIN32 )
 		g_qeglobals.m_strHomeGame = g_get_home_dir();
-		g_qeglobals.m_strHomeGame += "\\My Games\\";
+		g_qeglobals.m_strHomeGame += "\\My Documents\\My Games\\";
 		g_qeglobals.m_strHomeGame += m_pCurrentGameDescription->mUserPathPrefix.GetBuffer();
 		g_qeglobals.m_strHomeGame += "\\";
 #endif


### PR DESCRIPTION
I believe I had hacked in the My Games thing last year. It was wrong. Quake2World was wrong. The folder is not `Users\Joe\MyGames`, it's `Users\Joe\My Documents\My Games`. This is what NetRadiant uses, and in Googling "My Games folder Windows", it appears to be what the rest of the world uses, too.