### PR TITLE
Quake 1 Support

### DIFF
--- a/plugins/vfswad/vfs.cpp
+++ b/plugins/vfswad/vfs.cpp
@@ -164,6 +164,7 @@ static void vfsInitPakFile( const char *filename ){
 
 	strcpy( wadname,wadnameptr );
 	wadname[strlen( wadname ) - 4] = 0; // ditch the .wad so everthing looks nice!
+	strlwr( wadname );
 
 	g_wadFiles = g_slist_append( g_wadFiles, wf ); // store the wadfile handle
 

--- a/radiant/preferences.cpp
+++ b/radiant/preferences.cpp
@@ -3384,6 +3384,9 @@ void CGameInstall::BuildDialog() {
 	int iGame = 0;
 	while ( m_availGames[ iGame ] != GAME_NONE ) {
 		switch ( m_availGames[ iGame ] ) {
+		case GAME_Q1:
+			gtk_combo_box_append_text( GTK_COMBO_BOX( game_select_combo ), _( "Quake" ) );
+			break;
 		case GAME_Q2:
 			gtk_combo_box_append_text( GTK_COMBO_BOX( game_select_combo ), _( "Quake II" ) );
 			break;
@@ -3516,6 +3519,10 @@ void CGameInstall::Run() {
 	}
 
 	switch ( m_availGames[ m_nComboSelect ] ) {
+	case GAME_Q1:
+		gamePack = Q1_PACK;
+		gameFilePath += Q1_GAME;
+		break;
 	case GAME_Q2:
 		gamePack = Q2_PACK;
 		gameFilePath += Q2_GAME;
@@ -3606,6 +3613,15 @@ void CGameInstall::Run() {
 	}
 
 	switch ( m_availGames[ m_nComboSelect ] ) {
+	case GAME_Q1: {
+		fprintf( fg, "  idtech2=\"true\"\n" );
+		fprintf( fg, "  prefix=\".quake1\"\n" );
+		fprintf( fg, "  basegame=\"id1\"\n" );
+		fprintf( fg, "  no_patch=\"true\"\n" );
+		fprintf( fg, "  default_scale=\"1.0\"\n" );
+
+		break;
+	}
 	case GAME_Q2: {
 		fprintf( fg, "  idtech2=\"true\"\n" );
 		fprintf( fg, "  prefix=\".quake2\"\n" );
@@ -3810,6 +3826,9 @@ void CGameInstall::ScanGames() {
 		}
 		if ( stricmp( dirname, WOLF_PACK ) == 0) {
 			m_availGames[ iGame++ ] = GAME_WOLF;
+		}
+		if ( stricmp( dirname, Q1_PACK ) == 0 ) {
+			m_availGames[ iGame++ ] = GAME_Q1;
 		}
 	}
 	Sys_Printf( "No installable games found in: %s\n",

--- a/radiant/preferences.h
+++ b/radiant/preferences.h
@@ -216,6 +216,7 @@ void Dump();
 #define QL_GAME "ql.game"
 #define STVEF_GAME "stvef.game"
 #define WOLF_GAME "wolf.game"
+#define Q1_GAME "q1.game"
 
 #define Q3_PACK "Q3Pack"
 #define URT_PACK "UrTPack"
@@ -231,6 +232,7 @@ void Dump();
 #define QL_PACK "QLPack"
 #define STVEF_PACK "STVEFPack"
 #define WOLF_PACK "WolfPack"
+#define Q1_PACK "Q1Pack"
 
 class CGameInstall : public Dialog {
 public:
@@ -259,6 +261,7 @@ public:
 	GAME_QL,
 	GAME_STVEF,
 	GAME_WOLF,
+	GAME_Q1,
 	GAME_COUNT
   };
 


### PR DESCRIPTION
Pretty simple patch, most of the work was testing and making a gamepack.

I did some basic testing such as:
- Able to load existing q1 maps
- Maps are saved in the correct .map format (quake 1)
- Surface dialog for doing texture alignment seems to work
- Textures show up in the editor, with some quirks described below
- Displaying .mdl models for entities (monsters, etc) doesn't work and is probably difficult to add.

Some user documentation:
- For radiant to find them, texture wads should be in `quake/id1`, and the `wad` extension must be lowercase
- A restart is necessary for new wads added to the `id1` directory to show up in the texture menu 
- You have to add wad names to worldspawn (key/value "wad" "first.wad;second.wad;...") for textures to appear in the 3d view when loading a .map file. Choosing a wad from the texture menu just populates the texture browser with those textures.

Here is a game pack I prepared:
https://www.dropbox.com/s/uj8iewxy2q7ozmt/Q1Pack.zip?dl=0

It is based on the Quake 2 gamepack, but has a quake1.def file I got from quake community member gb. From what I understand, he added func_detail and func_group to a file from Alexander Malmberg which was extracted from the original QuakeC. So it should be under the GPL.
I wasn't able to get the .ent file from http://svn.icculus.org/gtkradiant-gamepacks/Q1Pack/trunk/q1.game/id1/ to load, otherwise I would have used that.
