### PR TITLE
Revert "entity.def: parser fix"

### DIFF
--- a/radiant/eclass_def.cpp
+++ b/radiant/eclass_def.cpp
@@ -159,9 +159,8 @@ eclass_t *Eclass_InitFromText( char *text ){
 	text++;
 
 	// get the size
-	t = COM_Parse( text );
+	text = COM_Parse( text );
 	if ( Get_COM_Token()[0] == '(' ) { // parse the size as two vectors
-                text = t;
 		e->fixedsize = true;
 		r = sscanf( text,"%f %f %f) (%f %f %f)", &e->mins[0], &e->mins[1], &e->mins[2],
 					&e->maxs[0], &e->maxs[1], &e->maxs[2] );


### PR DESCRIPTION
TTimo/GtkRadiant#263 broke existing .def files: for entities with no size given in the .def, it will make all of the spawnflag values wrong, so I suggest we revert this. 

Even if the .defs shipped with GTKR1.6 were all updated to the new format, there are a lot of mods out there that this would break.

See also discussion in https://github.com/TTimo/GtkRadiant/issues/262 and my response: https://github.com/TTimo/GtkRadiant/issues/262#issuecomment-111658768
