### PR TITLE
Adds misc_model_breakable entity rendering support for Jedi Academy.

### DIFF
--- a/radiant/xywindow.cpp
+++ b/radiant/xywindow.cpp
@@ -360,6 +360,7 @@ static const char *model_classnames[] =
 {
 	"misc_model",
 	"misc_model_static",
+	"misc_model_breakable",
 	"misc_gamemodel",
 	"model_static",
 };


### PR DESCRIPTION
Adds the breakable model entity support to list of models which can be rendered by radiant.  Mostly used in JA SP maps but some MP mods as well.

Ideally I'd like to look into adding static ghoul2 models (.glm) for radiant in picomodel at some point but its kind of over my head.