### PR TITLE
Include errno.h in plugins/vfspk3/vfs.cpp

### DIFF
--- a/plugins/vfspk3/vfs.cpp
+++ b/plugins/vfspk3/vfs.cpp
@@ -43,6 +43,7 @@
 
 #include <glib.h>
 #include <stdio.h>
+#include <errno.h>
 
 #if defined ( __linux__ ) || defined ( __APPLE__ )
   #include <dirent.h>


### PR DESCRIPTION
On Debian 7 there is an error when compiling plugins/vfspk3/vfs.cpp that errno is unknown. Including errno.h fixes the issue.