### PR TITLE
[tools/quake3/q3map2/light{,maps}_ydnar.c] Fix float-to-int conversion

### DIFF
--- a/tools/quake3/q3map2/light_ydnar.c
+++ b/tools/quake3/q3map2/light_ydnar.c
@@ -2033,7 +2033,7 @@ void IlluminateRawLightmap( int rawLightmapNum ){
 			}
 
 			/* set luxel filter radius */
-			luxelFilterRadius = superSample * filterRadius / lm->sampleSize;
+			luxelFilterRadius = lm->sampleSize != 0 ? superSample * filterRadius / lm->sampleSize : 0;
 			if ( luxelFilterRadius == 0 && ( filterRadius > 0.0f || filter ) ) {
 				luxelFilterRadius = 1;
 			}

--- a/tools/quake3/q3map2/lightmaps_ydnar.c
+++ b/tools/quake3/q3map2/lightmaps_ydnar.c
@@ -518,7 +518,7 @@ qboolean AddPatchToRawLightmap( int num, rawLightmap_t *lm ){
 	length = 0;
 	for ( x = 0; x < ( mesh->width - 1 ); x++ )
 		length += widthTable[ x ];
-	lm->w = ceil( length / lm->sampleSize ) + 1;
+	lm->w = lm->sampleSize != 0 ? ceil( length / lm->sampleSize ) + 1 : 0;
 	if ( lm->w < ds->patchWidth ) {
 		lm->w = ds->patchWidth;
 	}
@@ -531,7 +531,7 @@ qboolean AddPatchToRawLightmap( int num, rawLightmap_t *lm ){
 	length = 0;
 	for ( y = 0; y < ( mesh->height - 1 ); y++ )
 		length += heightTable[ y ];
-	lm->h = ceil( length / lm->sampleSize ) + 1;
+	lm->h = lm->sampleSize != 0 ? ceil( length / lm->sampleSize ) + 1 : 0;
 	if ( lm->h < ds->patchHeight ) {
 		lm->h = ds->patchHeight;
 	}


### PR DESCRIPTION
The conversion of a floating point value to an integer value has undefined behaviour if the value truncated to integer (mathematically) is not representable by the destination type. In particular, conversions from infinity and NaN have undefined behaviour.

The fix seems simple: Don't let NaN values occur in the first place by checking denominators.