### PR TITLE
Fix for potentially using uninitialized variable

### DIFF
--- a/libs/picomodel/lwo/envelope.c
+++ b/libs/picomodel/lwo/envelope.c
@@ -75,6 +75,8 @@ lwEnvelope *lwGetEnvelope( picoMemStream_t *fp, int cksize ){
 		goto Fail;
 	}
 
+	key = NULL;
+
 	/* process subchunks as they're encountered */
 
 	while ( 1 ) {

--- a/libs/picomodel/lwo/lwob.c
+++ b/libs/picomodel/lwo/lwob.c
@@ -244,6 +244,8 @@ lwSurface *lwGetSurface5( picoMemStream_t *fp, int cksize, lwObject *obj ){
 		goto Fail;
 	}
 
+	shdr = NULL;
+
 	/* process subchunks as they're encountered */
 
 	while ( 1 ) {
@@ -494,6 +496,9 @@ lwSurface *lwGetSurface5( picoMemStream_t *fp, int cksize, lwObject *obj ){
 			break;
 
 		case ID_SDAT:
+			if ( !shdr ) {
+				goto Fail;
+			}
 			shdr->data = getbytes( fp, sz );
 			break;
 


### PR DESCRIPTION
Might get used here uninitialized: https://github.com/TTimo/GtkRadiant/blob/master/libs/picomodel/lwo/envelope.c#L113
