### PR TITLE
Fix gcc warning iteration 86u invokes undefined behavior

### DIFF
--- a/radiant/texwindow.cpp
+++ b/radiant/texwindow.cpp
@@ -50,7 +50,7 @@
 #include "texmanip.h"
 
 #define TYP_MIPTEX  68
-static unsigned tex_palette[256];
+static unsigned tex_palette[256 * 3];
 
 #define FONT_HEIGHT 10
 


### PR DESCRIPTION
radiant/texwindow.cpp:188:29: warning: iteration 86u invokes undefined behavior [-Waggressive-loop-optimizations]
   tex_palette[i \* 3 + 0] = r;

See https://github.com/TTimo/GtkRadiant/blob/master/radiant/texwindow.cpp#L188
tex_palette is currently unused anyway.
