### PR TITLE
Fix gcc warning item may be used uninitialized in this function

### DIFF
--- a/radiant/mainframe.cpp
+++ b/radiant/mainframe.cpp
@@ -7172,6 +7172,7 @@ void MainFrame::OnGridPrev(){
 		case  64: item = GTK_WIDGET( g_object_get_data( G_OBJECT( m_pWidget ), "menu_grid_64" ) ); break;
 		case 128: item = GTK_WIDGET( g_object_get_data( G_OBJECT( m_pWidget ), "menu_grid_128" ) ); break;
 		case 256: item = GTK_WIDGET( g_object_get_data( G_OBJECT( m_pWidget ), "menu_grid_256" ) ); break;
+		default: return;
 		}
 
 	}


### PR DESCRIPTION
/usr/include/glib-2.0/gobject/gtype.h:2204:39: warning: ‘item’ may be used uninitialized in this function [-Wmaybe-uninitialized](%28ct*%29 g_type_check_instance_cast %28%28GTypeInstance*%29 ip, gt%29)
radiant/mainframe.cpp:7150:13: note: ‘item’ was declared here
  GtkWidget *item;
See https://github.com/TTimo/GtkRadiant/blob/master/radiant/mainframe.cpp#L7190
