### PR TITLE
import a q3map2 fix from netradiant

### DIFF
--- a/tools/quake3/q3map2/bsp.c
+++ b/tools/quake3/q3map2/bsp.c
@@ -778,7 +778,7 @@ int BSPMain( int argc, char **argv ){
 		else if ( !strcmp( argv[ i ], "-np" ) ) {
 			npDegrees = atof( argv[ i + 1 ] );
 			if ( npDegrees < 0.0f ) {
-				shadeAngleDegrees = 0.0f;
+				npDegrees = 0.0f;
 			}
 			else if ( npDegrees > 0.0f ) {
 				Sys_Printf( "Forcing nonplanar surfaces with a breaking angle of %f degrees\n", npDegrees );


### PR DESCRIPTION
this PR import a fix from netradiant's history. The commit title mentions two fixes but the other one was from a missing file, that's why the applied commit on GtkRadiant only references one fix.