### PR TITLE
More: Using Sys_FPrintf with SYS_WRN and SYS_ERR

### DIFF
--- a/tools/quake2/q2map/brushbsp.c
+++ b/tools/quake2/q2map/brushbsp.c
@@ -1293,7 +1293,7 @@ tree_t *BrushBSP( bspbrush_t *brushlist, vec3_t mins, vec3_t maxs ){
 
 		volume = BrushVolume( b );
 		if ( volume < microvolume ) {
-			Sys_Printf( "WARNING: entity %i, brush %i: microbrush\n",
+			Sys_FPrintf( SYS_WRN, "WARNING: entity %i, brush %i: microbrush\n",
 						b->original->entitynum, b->original->brushnum );
 		}
 

--- a/tools/quake2/q2map/faces.c
+++ b/tools/quake2/q2map/faces.c
@@ -653,7 +653,7 @@ int GetEdge2( int v1, int v2,  face_t *f ){
 			}
 	#if 0
 			if ( v1 == edge->v[0] && v2 == edge->v[1] ) {
-				Sys_Printf( "WARNING: multiple forward edge\n" );
+				Sys_FPrintf( SYS_WRN, "WARNING: multiple forward edge\n" );
 				return i;
 			}
 	#endif

--- a/tools/quake2/q2map/lightmap.c
+++ b/tools/quake2/q2map/lightmap.c
@@ -874,7 +874,7 @@ void CreateDirectLights( void ){
 			if ( target[0] ) { // point towards target
 				e2 = FindTargetEntity( target );
 				if ( !e2 ) {
-					Sys_Printf( "WARNING: light at (%i %i %i) has missing target\n",
+					Sys_FPrintf( SYS_WRN, "WARNING: light at (%i %i %i) has missing target\n",
 								(int)dl->origin[0], (int)dl->origin[1], (int)dl->origin[2] );
 				}
 				else

--- a/tools/quake2/q2map/main.c
+++ b/tools/quake2/q2map/main.c
@@ -649,7 +649,7 @@ int main( int argc, char **argv ){
 	Sys_Printf( "Game: %s\n", game );
 
 	if ( !do_info && !do_bsp && !do_vis && !do_rad ) {
-		Sys_Printf( "ERROR: -bsp, -vis, -light, nor -info specified.\nWhat to you want me to do?\n\n" );
+		Sys_FPrintf( SYS_ERR, "ERROR: -bsp, -vis, -light, nor -info specified.\nWhat to you want me to do?\n\n" );
 	}
 	else
 	{

--- a/tools/quake2/q2map/portals.c
+++ b/tools/quake2/q2map/portals.c
@@ -554,13 +554,13 @@ void MakeTreePortals_r( node_t *node ){
 
 	CalcNodeBounds( node );
 	if ( node->mins[0] >= node->maxs[0] ) {
-		Sys_Printf( "WARNING: node without a volume\n" );
+		Sys_FPrintf( SYS_WRN, "WARNING: node without a volume\n" );
 	}
 
 	for ( i = 0 ; i < 3 ; i++ )
 	{
 		if ( node->mins[i] < -8000 || node->maxs[i] > 8000 ) {
-			Sys_Printf( "WARNING: node with unbounded volume\n" );
+			Sys_FPrintf( SYS_WRN, "WARNING: node with unbounded volume\n" );
 			break;
 		}
 	}
@@ -756,7 +756,7 @@ void FloodAreas_r( node_t *node ){
 
 		// note the current area as bounding the portal
 		if ( e->portalareas[1] ) {
-			Sys_Printf( "WARNING: areaportal entity %i touches > 2 areas\n", b->original->entitynum );
+			Sys_FPrintf( SYS_WRN, "WARNING: areaportal entity %i touches > 2 areas\n", b->original->entitynum );
 			return;
 		}
 		if ( e->portalareas[0] ) {
@@ -854,7 +854,7 @@ void SetAreaPortalAreas_r( node_t *node ){
 		e = &entities[b->original->entitynum];
 		node->area = e->portalareas[0];
 		if ( !e->portalareas[1] ) {
-			Sys_Printf( "WARNING: areaportal entity %i doesn't touch two areas\n", b->original->entitynum );
+			Sys_FPrintf( SYS_WRN, "WARNING: areaportal entity %i doesn't touch two areas\n", b->original->entitynum );
 			return;
 		}
 	}

--- a/tools/quake2/q2map/qvis.c
+++ b/tools/quake2/q2map/qvis.c
@@ -209,7 +209,7 @@ void ClusterMerge( int leafnum ){
 	numvis = LeafVectorFromPortalVector( portalvector, uncompressed );
 
 	if ( uncompressed[leafnum >> 3] & ( 1 << ( leafnum & 7 ) ) ) {
-		Sys_Printf( "WARNING: Leaf portals saw into leaf\n" );
+		Sys_FPrintf( SYS_WRN, "WARNING: Leaf portals saw into leaf\n" );
 	}
 
 	uncompressed[leafnum >> 3] |= ( 1 << ( leafnum & 7 ) );

--- a/tools/quake3/common/aselib.c
+++ b/tools/quake3/common/aselib.c
@@ -472,7 +472,7 @@ static void ASE_KeyMAP_DIFFUSE( const char *token ){
 		else
 		{
 			sprintf( ase.materials[ase.numMaterials].name, "(not converted: '%s')", bitmap );
-			Sys_Printf( "WARNING: illegal material name '%s'\n", bitmap );
+			Sys_FPrintf( SYS_WRN, "WARNING: illegal material name '%s'\n", bitmap );
 		}
 	}
 	else


### PR DESCRIPTION
This commit do the same as “Using Sys_FPrintf with SYS_WRN and SYS_ERR” commit by @Pan7 (5105fc5) for occurrences that were left untouched (tools/ subtree only). This way the code is more consistent.

See [xonotic/netradiant!35](https://gitlab.com/xonotic/netradiant/merge_requests/35/) for the similar commit on NetRadiant side.