### PR TITLE
Now compiles on Ubuntu 16.10

### DIFF
--- a/libs/picomodel/picointernal.h
+++ b/libs/picomodel/picointernal.h
@@ -132,7 +132,7 @@ void            _pico_printf( int level, const char *format, ... );
 char            *_pico_stristr( char *str, const char *substr );
 void            _pico_unixify( char *path );
 int             _pico_nofname( const char *path, char *dest, int destSize );
-char            *_pico_nopath( const char *path );
+const char      *_pico_nopath( const char *path );
 char            *_pico_setfext( char *path, const char *ext );
 int             _pico_getline( char *buf, int bufsize, char *dest, int destsize );
 char            *_pico_strlwr( char *str );

--- a/libs/picomodel/picomodel.vcproj
+++ b/libs/picomodel/picomodel.vcproj
@@ -192,6 +192,10 @@
 				RelativePath=".\pm_obj.c"
 				>
 			</File>
+			<File
+				RelativePath=".\pm_terrain.c"
+				>
+			</File>
 			<Filter
 				Name="lwo"
 				Filter="cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx"


### PR DESCRIPTION
This fixes compiling on Ubuntu 16.10.

Most notable this adds "pm_terrain.c" to the vcproj-file instead of just the vcxproj-file.

It also fixes the declaration for "_pico_nopath" as it fails on gcc 6.2.0 by default.