### PR TITLE
Fix gcc warning type may be used uninitialized

### DIFF
--- a/contrib/camera/dialogs.cpp
+++ b/contrib/camera/dialogs.cpp
@@ -602,6 +602,9 @@ static gint ci_add_target( GtkWidget *widget, gpointer data ){
 				else if ( gtk_toggle_button_get_active( (GtkToggleButton*)spline ) ) {
 					type = 2;
 				}
+				else {
+					break;
+				}
 
 				// Add the target
 				GetCurrentCam()->GetCam()->addTarget( str, static_cast<idCameraPosition::positionType>( type ) );


### PR DESCRIPTION
Fix for:
contrib/camera/dialogs.cpp:593:9: warning: ‘type’ may be used uninitialized in this function [-Wmaybe-uninitialized]