### PR TITLE
Fix gcc warning tex may be used uninitialized in this function

### DIFF
--- a/libs/picomodel/lwo/lwob.c
+++ b/libs/picomodel/lwo/lwob.c
@@ -246,6 +246,7 @@ lwSurface *lwGetSurface5( picoMemStream_t *fp, int cksize, lwObject *obj ){
 		goto Fail;
 	}
 
+	tex = NULL;
 	shdr = NULL;
 
 	/* process subchunks as they're encountered */
@@ -386,6 +387,9 @@ lwSurface *lwGetSurface5( picoMemStream_t *fp, int cksize, lwObject *obj ){
 		case ID_TFLG:
 			flags = getU2( fp );
 
+			if( tex == NULL ) {
+				break;
+			}
 			//only one of the three axis bits should be set
 			if ( flags & 1 ) {
 				tex->axis = 0;
@@ -421,21 +425,33 @@ lwSurface *lwGetSurface5( picoMemStream_t *fp, int cksize, lwObject *obj ){
 			break;
 
 		case ID_TSIZ:
+			if( tex == NULL ) {
+				break;
+			}
 			for ( i = 0; i < 3; i++ )
 				tex->tmap.size.val[ i ] = getF4( fp );
 			break;
 
 		case ID_TCTR:
+			if( tex == NULL ) {
+				break;
+			}
 			for ( i = 0; i < 3; i++ )
 				tex->tmap.center.val[ i ] = getF4( fp );
 			break;
 
 		case ID_TFAL:
+			if( tex == NULL ) {
+				break;
+			}
 			for ( i = 0; i < 3; i++ )
 				tex->tmap.falloff.val[ i ] = getF4( fp );
 			break;
 
 		case ID_TVEL:
+			if( tex == NULL ) {
+				break;
+			}
 			for ( i = 0; i < 3; i++ )
 				v[ i ] = getF4( fp );
 			tex->tmap.center.eindex = add_tvel( tex->tmap.center.val, v,
@@ -443,6 +459,9 @@ lwSurface *lwGetSurface5( picoMemStream_t *fp, int cksize, lwObject *obj ){
 			break;
 
 		case ID_TCLR:
+			if( tex == NULL ) {
+				break;
+			}
 			if ( tex->type == ID_PROC ) {
 				for ( i = 0; i < 3; i++ )
 					tex->param.proc.value[ i ] = getU1( fp ) / 255.0f;
@@ -450,40 +469,64 @@ lwSurface *lwGetSurface5( picoMemStream_t *fp, int cksize, lwObject *obj ){
 			break;
 
 		case ID_TVAL:
+			if( tex == NULL ) {
+				break;
+			}
 			tex->param.proc.value[ 0 ] = getI2( fp ) / 256.0f;
 			break;
 
 		case ID_TAMP:
+			if( tex == NULL ) {
+				break;
+			}
 			if ( tex->type == ID_IMAP ) {
 				tex->param.imap.amplitude.val = getF4( fp );
 			}
 			break;
 
 		case ID_TIMG:
+			if( tex == NULL ) {
+				break;
+			}
 			s = getS0( fp );
 			tex->param.imap.cindex = add_clip( s, &obj->clip, &obj->nclips );
 			break;
 
 		case ID_TAAS:
+			if( tex == NULL ) {
+				break;
+			}
 			tex->param.imap.aa_strength = getF4( fp );
 			tex->param.imap.aas_flags = 1;
 			break;
 
 		case ID_TREF:
+			if( tex == NULL ) {
+				break;
+			}
 			tex->tmap.ref_object = getbytes( fp, sz );
 			break;
 
 		case ID_TOPC:
+			if( tex == NULL ) {
+				break;
+			}
 			tex->opacity.val = getF4( fp );
 			break;
 
 		case ID_TFP0:
+			if( tex == NULL ) {
+				break;
+			}
 			if ( tex->type == ID_IMAP ) {
 				tex->param.imap.wrapw.val = getF4( fp );
 			}
 			break;
 
 		case ID_TFP1:
+			if( tex == NULL ) {
+				break;
+			}
 			if ( tex->type == ID_IMAP ) {
 				tex->param.imap.wraph.val = getF4( fp );
 			}


### PR DESCRIPTION
Fix for:
libs/picomodel/lwo/lwob.c:488:31: warning: ‘tex’ may be used uninitialized in this function [-Wmaybe-uninitialized]
See TTEX section in the Lightwave object format doc at http://paulbourke.net/dataformats/lightwave/