### PR TITLE
q3map2: don't store lightmap if the last bounce computation ran empty.

### DIFF
--- a/tools/quake3/q3map2/light.c
+++ b/tools/quake3/q3map2/light.c
@@ -1772,7 +1772,7 @@ void LightWorld( void ){
 		SetupEnvelopes( qfalse, fastbounce );
 		if ( numLights == 0 ) {
 			Sys_Printf( "No diffuse light to calculate, ending radiosity.\n" );
-			break;
+			return;
 		}
 
 		/* add to lightgrid */
@@ -1813,6 +1813,9 @@ void LightWorld( void ){
 		bounce--;
 		b++;
 	}
+	/* ydnar: store off lightmaps */
+	StoreSurfaceLightmaps();
+
 }
 
 
@@ -2300,9 +2303,6 @@ int LightMain( int argc, char **argv ){
 
 	/* light the world */
 	LightWorld();
-
-	/* ydnar: store off lightmaps */
-	StoreSurfaceLightmaps();
 
 	/* write out the bsp */
 	UnparseEntities();


### PR DESCRIPTION
Hi, this backports a change I did to the netradiant fork of xonotic.

I noticed that when computing bounce lights, q3map2 would
````
compute bounce 1 of n
store lightmaps
compute bounce 2 of n
store lightmaps
compute bounce 3 of n
find out there are no lights left to compute
store lightmaps  // <- this is redundant since we already have bounce 3 stored
terminate
````

Storing lightmaps can be quite expensive on large maps with small sample size and a lot of brushes, especially since it does not seem to be multithreaded.
A better solution might be to just really store the lightmaps once and just keep everything in memory, but I don't think I can implement this yet.

I did not test the changeset  with GtkRadiants q3map2 since it didn't seem to want to compile xonotic maps, but in our fork, it looked like the change is fine.
https://gitlab.com/xonotic/netradiant/merge_requests/9