### PR TITLE
Main app window for surface plugins

### DIFF
--- a/plugins/surface/surfacedialog.cpp
+++ b/plugins/surface/surfacedialog.cpp
@@ -102,6 +102,8 @@ bool g_bListenChanged = true;
 // turn on/off listening of the update messages
 bool g_bListenUpdate = true;
 
+extern void *g_pMainWidget;
+
 GtkWidget* create_SurfaceInspector( void );
 GtkWidget *SurfaceInspector = NULL;
 
@@ -644,6 +646,7 @@ GtkWidget* create_SurfaceInspector( void ){
 	GtkSizeGroup *size_group;
 
 	SurfaceInspector = gtk_window_new( GTK_WINDOW_TOPLEVEL );
+	gtk_window_set_transient_for( GTK_WINDOW( SurfaceInspector ), GTK_WINDOW( g_pMainWidget ) );
 	gtk_container_set_border_width( GTK_CONTAINER( SurfaceInspector ), 4 );
 	gtk_window_set_title( GTK_WINDOW( SurfaceInspector ), _( "Surface Inspector" ) );
 

--- a/plugins/surface/surfdlg_plugin.cpp
+++ b/plugins/surface/surfdlg_plugin.cpp
@@ -34,6 +34,9 @@
 
 #include "synapse.h"
 
+void *g_pMainWidget;
+const char* QERPlug_Init( void* hApp, void *pWidget );
+
 class CSynapseClient_SurfDLG : public CSynapseClient
 {
 public:
@@ -117,4 +120,11 @@ const char* CSynapseClient_SurfDLG::GetName(){
 
 bool CSynapseClient_SurfDLG::OnActivate(){
 	return true;
+}
+
+const char* QERPlug_Init( void* hApp, void *pWidget ){
+
+	g_pMainWidget = pWidget;
+
+	return "Quake3 Surface Dialog for Radiant";
 }

--- a/plugins/surface_idtech2/surfacedialog.cpp
+++ b/plugins/surface_idtech2/surfacedialog.cpp
@@ -80,6 +80,8 @@ bool g_bListenChanged = TRUE;
 // turn on/off listening of the update messages
 bool g_bListenUpdate = TRUE;
 
+extern void *g_pMainWidget;
+
 GtkWidget* create_SurfaceInspector( void );
 GtkWidget *SurfaceInspector = NULL;
 
@@ -551,6 +553,7 @@ GtkWidget* create_SurfaceInspector( void ){
 	GtkWidget *hbox1;
 
 	SurfaceInspector = gtk_window_new( GTK_WINDOW_TOPLEVEL );
+	gtk_window_set_transient_for( GTK_WINDOW( SurfaceInspector ), GTK_WINDOW( g_pMainWidget ) );
 	gtk_container_set_border_width( GTK_CONTAINER( SurfaceInspector ), 4 );
 	gtk_window_set_title( GTK_WINDOW( SurfaceInspector ), _( "Surface Inspector" ) );
 

--- a/plugins/surface_idtech2/surfdlg_plugin.cpp
+++ b/plugins/surface_idtech2/surfdlg_plugin.cpp
@@ -34,6 +34,9 @@
 
 #include "synapse.h"
 
+void *g_pMainWidget;
+const char* QERPlug_Init( void* hApp, void *pWidget );
+
 _QERFuncTable_1 g_FuncTable;
 _QERUndoTable g_UndoTable;
 _QERAppSurfaceTable g_AppSurfaceTable;
@@ -106,4 +109,11 @@ bool CSynapseClient_SurfDLG::RequestAPI( APIDescriptor_t *pAPI ) {
 
 const char *CSynapseClient_SurfDLG::GetInfo(){
 	return "Surface Dialog (idTech2) module built " __DATE__ " " RADIANT_VERSION;
+}
+
+const char* QERPlug_Init( void* hApp, void *pWidget ){
+
+	g_pMainWidget = pWidget;
+
+	return "idTech2 Surface Dialog for Radiant";
 }


### PR DESCRIPTION
This is unfinshed yet.
Need a way to register QERPlug_Init.

The main window is required because "Dialog windows should be set transient for the main application window". SetWinPos_from_Prefs() -> load_window_pos() is used to center the surface dialog window.
https://developer.gnome.org/gtk3/stable/GtkWindow.html#gtk-window-set-transient-for