### PR TITLE
Replace deprecated gdk_cursor_new

### DIFF
--- a/contrib/gtkgensurf/view.cpp
+++ b/contrib/gtkgensurf/view.cpp
@@ -307,9 +307,20 @@ static void motion( GtkWidget *widget, GdkEventMotion *event, gpointer data ){
 	g_GLTable.m_pfn_qglClear( GL_COLOR_BUFFER_BIT );
 
 	if ( PtInRect( &rcGrid,pt ) ) {
-		GdkCursor *cursor = gdk_cursor_new( GDK_CROSS );
-		gdk_window_set_cursor( gtk_widget_get_window( g_pWndPreview ), cursor );
+		GdkWindow *window;
+		GdkDisplay *display;
+		GdkCursor *cursor;
+
+		window = gtk_widget_get_window( g_pWndPreview );
+		display = gdk_window_get_display( window );
+		cursor = gdk_cursor_new_for_display( display, GDK_CROSS );
+
+		gdk_window_set_cursor( window, cursor );
+#if GTK_CHECK_VERSION( 3, 0, 0 )
+		g_object_unref( cursor );
+#else
 		gdk_cursor_unref( cursor );
+#endif
 
 		char Text[32];
 		int x, y;

--- a/radiant/camwindow.cpp
+++ b/radiant/camwindow.cpp
@@ -490,26 +490,15 @@ void CamWnd::ToggleFreeMove(){
 	}
 
 	if ( m_bFreeMove ) {
+		GdkDisplay *display;
+		GdkCursor *cursor;
 
 		SetFocus();
 		SetCapture();
 
-		{
-			GdkPixmap *pixmap;
-			GdkBitmap *mask;
-			char buffer [( 32 * 32 ) / 8];
-			memset( buffer, 0, ( 32 * 32 ) / 8 );
-			GdkColor white = {0, 0xffff, 0xffff, 0xffff};
-			GdkColor black = {0, 0x0000, 0x0000, 0x0000};
-			pixmap = gdk_bitmap_create_from_data( NULL, buffer, 32, 32 );
-			mask   = gdk_bitmap_create_from_data( NULL, buffer, 32, 32 );
-			GdkCursor *cursor = gdk_cursor_new_from_pixmap( pixmap, mask, &white, &black, 1, 1 );
-
-			gdk_window_set_cursor( window, cursor );
-			gdk_cursor_unref( cursor );
-			gdk_drawable_unref( pixmap );
-			gdk_drawable_unref( mask );
-		}
+		display = gdk_window_get_display( window );
+		cursor = gdk_cursor_new_for_display( display, GDK_BLANK_CURSOR );
+		gdk_window_set_cursor( window, cursor );
 
 		// RR2DO2: FIXME why does this only work the 2nd and
 		// further times the event is called? (floating windows
@@ -529,16 +518,30 @@ void CamWnd::ToggleFreeMove(){
 
 			gdk_pointer_grab( gtk_widget_get_window( widget ), TRUE, mask, gtk_widget_get_window( widget ), NULL, GDK_CURRENT_TIME );
 		}
+#if GTK_CHECK_VERSION( 3, 0, 0 )
+		g_object_unref( cursor );
+#else
+		gdk_cursor_unref( cursor );
+#endif
 	}
 	else
 	{
+		GdkDisplay *display;
+		GdkCursor *cursor;
+
 		gdk_pointer_ungrab( GDK_CURRENT_TIME );
 
 		g_signal_handler_disconnect( G_OBJECT( widget ), m_FocusOutHandler_id );
 
-		GdkCursor *cursor = gdk_cursor_new( GDK_LEFT_PTR );
+		display = gdk_window_get_display( window );
+		cursor = gdk_cursor_new_for_display( display, GDK_LEFT_PTR );
+
 		gdk_window_set_cursor( window, cursor );
+#if GTK_CHECK_VERSION( 3, 0, 0 )
+		g_object_unref( cursor );
+#else
 		gdk_cursor_unref( cursor );
+#endif
 
 		ReleaseCapture();
 	}

--- a/radiant/qe3.cpp
+++ b/radiant/qe3.cpp
@@ -1280,16 +1280,39 @@ void Sys_SetTitle( const char *text ){
 bool g_bWaitCursor = false;
 
 void WINAPI Sys_BeginWait( void ){
-	GdkCursor *cursor = gdk_cursor_new( GDK_WATCH );
-	gdk_window_set_cursor( gtk_widget_get_window( g_pParentWnd->m_pWidget ), cursor );
+	GdkWindow *window;
+	GdkDisplay *display;
+	GdkCursor *cursor;
+
+	window = gtk_widget_get_window( g_pParentWnd->m_pWidget );
+	display = gdk_window_get_display( window );
+	cursor = gdk_cursor_new_for_display( display, GDK_WATCH );
+	gdk_window_set_cursor( window, cursor );
+#if GTK_CHECK_VERSION( 3, 0, 0 )
+	g_object_unref( cursor );
+#else
 	gdk_cursor_unref( cursor );
+#endif
+
 	g_bWaitCursor = true;
 }
 
 void WINAPI Sys_EndWait( void ){
-	GdkCursor *cursor = gdk_cursor_new( GDK_LEFT_PTR );
-	gdk_window_set_cursor( gtk_widget_get_window( g_pParentWnd->m_pWidget ), cursor );
+	GdkWindow *window;
+	GdkDisplay *display;
+	GdkCursor *cursor;
+
+	window = gtk_widget_get_window( g_pParentWnd->m_pWidget );
+	display = gdk_window_get_display( window );
+	cursor = gdk_cursor_new_for_display( display, GDK_LEFT_PTR );
+
+	gdk_window_set_cursor( window, cursor );
+#if GTK_CHECK_VERSION( 3, 0, 0 )
+	g_object_unref( cursor );
+#else
 	gdk_cursor_unref( cursor );
+#endif
+
 	g_bWaitCursor = false;
 }
 

--- a/radiant/xywindow.cpp
+++ b/radiant/xywindow.cpp
@@ -1165,10 +1165,19 @@ void XYWnd::OnMouseMove( guint32 nFlags, int pointx, int pointy ){
 
 	if ( ( nFlags & MK_RBUTTON ) == 0 ) {
 		if ( bCrossHair && !g_bWaitCursor ) {
+			GdkWindow *window;
+			GdkDisplay *display;
 			GdkCursor *cursor;
-			cursor = gdk_cursor_new( GDK_CROSSHAIR );
-			gdk_window_set_cursor( gtk_widget_get_window( m_pWidget ), cursor );
+
+			window = gtk_widget_get_window( m_pWidget );
+			display = gdk_window_get_display( window );
+			cursor = gdk_cursor_new_for_display( display, GDK_CROSSHAIR );
+			gdk_window_set_cursor( window, cursor );
+#if GTK_CHECK_VERSION( 3, 0, 0 )
+			g_object_unref( cursor );
+#else
 			gdk_cursor_unref( cursor );
+#endif
 		}
 		else
 		{
@@ -1833,19 +1842,20 @@ void XYWnd::XY_MouseMoved( int x, int y, int buttons ){
 
 			// create an empty cursor
 			if ( !g_bWaitCursor ) {
-				GdkPixmap *pixmap;
-				GdkBitmap *mask;
-				char buffer [( 32 * 32 ) / 8];
-				memset( buffer, 0, ( 32 * 32 ) / 8 );
-				GdkColor white = {0, 0xffff, 0xffff, 0xffff};
-				GdkColor black = {0, 0x0000, 0x0000, 0x0000};
-				pixmap = gdk_bitmap_create_from_data( NULL, buffer, 32, 32 );
-				mask   = gdk_bitmap_create_from_data( NULL, buffer, 32, 32 );
-				GdkCursor *cursor = gdk_cursor_new_from_pixmap( pixmap, mask, &white, &black, 1, 1 );
-				gdk_window_set_cursor( gtk_widget_get_window( m_pWidget ), cursor );
+				GdkWindow *window;
+				GdkDisplay *display;
+				GdkCursor *cursor;
+
+				window = gtk_widget_get_window( m_pWidget );
+				display = gdk_window_get_display( window );
+				cursor = gdk_cursor_new_for_display( display, GDK_BLANK_CURSOR );
+
+				gdk_window_set_cursor( window, cursor );
+#if GTK_CHECK_VERSION( 3, 0, 0 )
+				g_object_unref( cursor );
+#else
 				gdk_cursor_unref( cursor );
-				gdk_drawable_unref( pixmap );
-				gdk_drawable_unref( mask );
+#endif
 			}
 
 			Sys_UpdateWindows( W_XY | W_XY_OVERLAY );


### PR DESCRIPTION
Can't use g_object_unref for cursors in GTK2.