### PR TITLE
Update gitignore to cleanup some build spam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 /tools/urt/tools/quake3/q3map2/Debug
 /tools/urt/tools/quake3/q3map2/Release
 /.sconsign.dblite
-/.vs/radiant/v14/.suo
+/.vs/*
 /radiant.opensdf
 /radiant.sdf
 /radiant.suo
@@ -17,6 +17,8 @@
 /radiant.VC.db
 /site.sconf
 
+*.log
+*.pdb
 *.obj
 *.pyc
 *.so


### PR DESCRIPTION
Noticed a lot of spam on newer VS builds. Primarily 2017 so I updated these to cut out a lot of cruft from git status log that doesn't belong on the repo.