### PR TITLE
Fix delete and comparison warning

### DIFF
--- a/contrib/bobtoolz/visfind.cpp
+++ b/contrib/bobtoolz/visfind.cpp
@@ -207,7 +207,7 @@ list<DWinding*> *CreateTrace( dleaf_t *leaf, int c, vis_header *header, byte *vi
 		}
 	}
 
-	delete repeatlist;
+	delete[] repeatlist;
 
 	return pointlist;
 }

--- a/contrib/prtview/portals.cpp
+++ b/contrib/prtview/portals.cpp
@@ -235,7 +235,7 @@ void CPortals::Load(){
 		return;
 	}
 
-	if ( portal_count < 0 ) {
+	if ( portal_count <= 0 ) {
 		fclose( in );
 
 		portal_count = 0;


### PR DESCRIPTION
contrib/bobtoolz/visfind.cpp:210:2: warning: 'delete' applied to a pointer that was allocated with 'new[]'; did you mean 'delete[]'? [-Wmismatched-new-delete]
contrib/prtview/portals.cpp:238:20: warning: comparison of unsigned expression < 0 is always false [-Wtautological-compare]
See https://github.com/TTimo/GtkRadiant/issues/467