### PR TITLE
Fix uninitialized use of ext warning

### DIFF
--- a/tools/quake3/q3map2/shaders.c
+++ b/tools/quake3/q3map2/shaders.c
@@ -1233,6 +1233,9 @@ static void ParseShaderFile( const char *filename ){
 				if ( !Q_stricmp( token, "q3map_sunext" ) ) {
 					ext = qtrue;
 				}
+				else {
+					ext = qfalse;
+				}
 
 				/* allocate sun */
 				sun = safe_malloc( sizeof( *sun ) );


### PR DESCRIPTION
tools/quake3/q3map2/shaders.c:1233:10: warning: variable 'ext' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
                                if ( !Q_stricmp( token, "q3map_sunext" ) ) {
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
tools/quake3/q3map2/shaders.c:1276:10: note: uninitialized use occurs here
                                if ( ext && TokenAvailable() ) {
                                     ^~~
ext needs to be initialized.
See https://github.com/TTimo/GtkRadiant/issues/467