### PR TITLE
Fix missing sentinel warning

### DIFF
--- a/radiant/gtkdlgs.cpp
+++ b/radiant/gtkdlgs.cpp
@@ -1869,7 +1869,7 @@ void DoNewPatchDlg(){
 	cells = gtk_cell_layout_get_cells( GTK_CELL_LAYOUT( combo ) );
 	for( lst = cells; lst != NULL; lst = g_list_next( lst ) )
 	{
-		g_object_set( lst->data, "xalign", 1.0, NULL );
+		g_object_set( G_OBJECT( lst->data ), "xalign", 1.0, (char*)NULL );
 	}
 	g_list_free( cells );
 
@@ -1887,7 +1887,7 @@ void DoNewPatchDlg(){
 	cells = gtk_cell_layout_get_cells( GTK_CELL_LAYOUT( combo ) );
 	for( lst = cells; lst != NULL; lst = g_list_next( lst ) )
 	{
-		g_object_set( lst->data, "xalign", 1.0, NULL );
+		g_object_set( G_OBJECT( lst->data ), "xalign", 1.0, (char*)NULL );
 	}
 	g_list_free( cells );
 

--- a/radiant/gtkmisc.cpp
+++ b/radiant/gtkmisc.cpp
@@ -1465,7 +1465,7 @@ const char* file_dialog( void *parent, gboolean open, const char* title, const c
 	*w = '\0';
 
 	action = open ? GTK_FILE_CHOOSER_ACTION_OPEN : GTK_FILE_CHOOSER_ACTION_SAVE;
-	file_sel = gtk_file_chooser_dialog_new( title, GTK_WINDOW( parent ), action, NULL, NULL );
+	file_sel = gtk_file_chooser_dialog_new( title, GTK_WINDOW( parent ), action, NULL, (char*)NULL );
 	gtk_dialog_add_button( GTK_DIALOG( file_sel ), open ? _( "Open" ) : _("Save" ), GTK_RESPONSE_ACCEPT );
 	gtk_dialog_add_button( GTK_DIALOG( file_sel ), _( "Cancel" ), GTK_RESPONSE_CANCEL );
 
@@ -1588,7 +1588,7 @@ char* WINAPI dir_dialog( void *parent, const char* title, const char* path ){
 	gint response_id;
 	GtkFileChooserAction action = GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER;
 
-	file_sel = gtk_file_chooser_dialog_new( title, GTK_WINDOW( parent ), action, NULL, NULL );
+	file_sel = gtk_file_chooser_dialog_new( title, GTK_WINDOW( parent ), action, NULL, (char*)NULL );
 	gtk_dialog_add_button( GTK_DIALOG( file_sel ), _( "OK" ), GTK_RESPONSE_ACCEPT );
 	gtk_dialog_add_button( GTK_DIALOG( file_sel ), _( "Cancel" ), GTK_RESPONSE_CANCEL );
 

--- a/radiant/patchdialog.cpp
+++ b/radiant/patchdialog.cpp
@@ -361,7 +361,7 @@ void PatchDialog::BuildDialog(){
 	cells = gtk_cell_layout_get_cells( GTK_CELL_LAYOUT( combo ) );
 	for( lst = cells; lst != NULL; lst = g_list_next( lst ) )
 	{
-		g_object_set( lst->data, "xalign", 1.0, NULL );
+		g_object_set( G_OBJECT( lst->data ), "xalign", 1.0, (char*)NULL );
 	}
 	g_list_free( cells );
 
@@ -377,7 +377,7 @@ void PatchDialog::BuildDialog(){
 	cells = gtk_cell_layout_get_cells( GTK_CELL_LAYOUT( combo ) );
 	for( lst = cells; lst != NULL; lst = g_list_next( lst ) )
 	{
-		g_object_set( lst->data, "xalign", 1.0, NULL );
+		g_object_set( G_OBJECT( lst->data ), "xalign", 1.0, (char*)NULL );
 	}
 	g_list_free( cells );
 


### PR DESCRIPTION
radiant/gtkdlgs.cpp:1872:47: warning: missing sentinel in function call [-Wsentinel]
                g_object_set( lst->data, "xalign", 1.0, NULL );
radiant/gtkdlgs.cpp:1890:47: warning: missing sentinel in function call [-Wsentinel]
                g_object_set( lst->data, "xalign", 1.0, NULL );
radiant/patchdialog.cpp:364:47: warning: missing sentinel in function call [-Wsentinel]
                g_object_set( lst->data, "xalign", 1.0, NULL );
radiant/patchdialog.cpp:380:47: warning: missing sentinel in function call [-Wsentinel]
                g_object_set( lst->data, "xalign", 1.0, NULL );
