### PR TITLE
Fix abs warning

### DIFF
--- a/plugins/textool/TexTool.cpp
+++ b/plugins/textool/TexTool.cpp
@@ -264,15 +264,15 @@ void FitView( IWindow* hwndDlg, int TexSize[2] ){
 	float TSize = (float)fabs( g_2DView.m_Maxs[1] - g_2DView.m_Mins[1] );
 	float XSize = TexSize[0] * SSize;
 	float YSize = TexSize[1] * TSize;
-	float RatioX = XSize / (float)abs( g_2DView.m_rect.left - g_2DView.m_rect.right );
-	float RatioY = YSize / (float)abs( g_2DView.m_rect.top - g_2DView.m_rect.bottom );
+	float RatioX = XSize / (float)fabs( g_2DView.m_rect.left - g_2DView.m_rect.right );
+	float RatioY = YSize / (float)fabs( g_2DView.m_rect.top - g_2DView.m_rect.bottom );
 	if ( RatioX > RatioY ) {
-		YSize = (float)abs( g_2DView.m_rect.top - g_2DView.m_rect.bottom ) * RatioX;
+		YSize = (float)fabs( g_2DView.m_rect.top - g_2DView.m_rect.bottom ) * RatioX;
 		TSize = YSize / (float)TexSize[1];
 	}
 	else
 	{
-		XSize = (float)abs( g_2DView.m_rect.left - g_2DView.m_rect.right ) * RatioY;
+		XSize = (float)fabs( g_2DView.m_rect.left - g_2DView.m_rect.right ) * RatioY;
 		SSize = XSize / (float)TexSize[0];
 	}
 	g_2DView.m_Mins[0] = g_2DView.m_Center[0] - 0.5f * SSize;


### PR DESCRIPTION
plugins/textool/TexTool.cpp:267:32: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
        float RatioX = XSize / (float)abs( g_2DView.m_rect.left - g_2DView.m_rect.right );
                                      ^
plugins/textool/TexTool.cpp:267:32: note: use function 'std::abs' instead
        float RatioX = XSize / (float)abs( g_2DView.m_rect.left - g_2DView.m_rect.right );
                                      ^~~
                                      std::abs
plugins/textool/TexTool.cpp:267:32: note: include the header <cstdlib> or explicitly provide a declaration for 'std::abs'
plugins/textool/TexTool.cpp:268:32: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
        float RatioY = YSize / (float)abs( g_2DView.m_rect.top - g_2DView.m_rect.bottom );
                                      ^
plugins/textool/TexTool.cpp:268:32: note: use function 'std::abs' instead
        float RatioY = YSize / (float)abs( g_2DView.m_rect.top - g_2DView.m_rect.bottom );
                                      ^~~
                                      std::abs
plugins/textool/TexTool.cpp:268:32: note: include the header <cstdlib> or explicitly provide a declaration for 'std::abs'
plugins/textool/TexTool.cpp:270:18: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
                YSize = (float)abs( g_2DView.m_rect.top - g_2DView.m_rect.bottom ) * RatioX;
                               ^
plugins/textool/TexTool.cpp:270:18: note: use function 'std::abs' instead
                YSize = (float)abs( g_2DView.m_rect.top - g_2DView.m_rect.bottom ) * RatioX;
                               ^~~
                               std::abs
plugins/textool/TexTool.cpp:270:18: note: include the header <cstdlib> or explicitly provide a declaration for 'std::abs'
plugins/textool/TexTool.cpp:275:18: warning: absolute value function 'abs' given an argument of type 'long' but has parameter of type 'int' which may cause truncation of value [-Wabsolute-value]
                XSize = (float)abs( g_2DView.m_rect.left - g_2DView.m_rect.right ) * RatioY;
                               ^
plugins/textool/TexTool.cpp:275:18: note: use function 'std::abs' instead
                XSize = (float)abs( g_2DView.m_rect.left - g_2DView.m_rect.right ) * RatioY;
                               ^~~

See https://github.com/TTimo/GtkRadiant/issues/467