### PR TITLE
Remove unused var g_cNull

### DIFF
--- a/contrib/camera/dialogs.cpp
+++ b/contrib/camera/dialogs.cpp
@@ -39,7 +39,6 @@ static GtkLabel *g_pTotalTime = NULL;
 static GtkAdjustment *g_pTimeLine = NULL;
 static GtkWidget *g_pTrackCamera = NULL;
 static GtkWidget *g_pCamName = NULL;
-static char *g_cNull = '\0';
 
 #define EVENT_TEXT_COLUMN (0)
 #define EVENT_INDEX_COLUMN (1)


### PR DESCRIPTION
contrib/camera/dialogs.cpp:42:14: warning: unused variable 'g_cNull' [-Wunused-variable]
contrib/camera/dialogs.cpp:42:24: warning: expression which evaluates to zero treated as a null pointer constant of type 'char *' [-Wnon-literal-null-conversion]
static char *g_cNull = '\0';
See https://github.com/TTimo/GtkRadiant/issues/467