### PR TITLE
Model browsing: move "All supported types" to top

### DIFF
--- a/radiant/gtkmisc.cpp
+++ b/radiant/gtkmisc.cpp
@@ -1330,17 +1330,6 @@ const char* file_dialog( void *parent, gboolean open, const char* title, const c
 	CFileType typelist;
 	if ( pattern != NULL ) {
 		GetFileTypeRegistry()->getTypeList( pattern, &typelist );
-
-		// kaz - viewing all file types at once is really convenient for model selection
-		if ( !strcmp( "Open Model", title ) ) {
-			CString allTypesFilter;
-			for( int i = 0; i < typelist.GetNumTypes(); i++ ) {
-				allTypesFilter += typelist.GetTypeForIndex(i).pattern;
-				if ( i < typelist.GetNumTypes() - 1 )
-					allTypesFilter += ";";
-			}
-			typelist.addType(filetype_t("All supported types", allTypesFilter.GetBuffer()));
-		}
 	}
 
 #ifdef _WIN32
@@ -1360,12 +1349,6 @@ const char* file_dialog( void *parent, gboolean open, const char* title, const c
 		                      // "select the first filter as default".
 		if ( pattern ) {
 			ofn.lpstrFilter = typelist.m_strWin32Filters;
-			
-			// kaz - the "all supported types" will be at bottom of list
-			// ...idiomatically uncouth but not worth fixing
-			if ( !strcmp( "Open Model", title ) ) {
-				ofn.nFilterIndex = typelist.GetNumTypes();
-			}
 		}
 		else
 		{

--- a/radiant/pluginmanager.cpp
+++ b/radiant/pluginmanager.cpp
@@ -91,8 +91,27 @@ virtual void addType( const char* key, filetype_t type ){
 }
 virtual void getTypeList( const char* key, IFileTypeList* typelist ){
 	filetype_list_t& list_ref = m_typelists[key];
-	for ( unsigned int i = 0; i < list_ref.size(); ++i )
+
+	if (key == "model") {
+		// Get the list of all supported types (adapted from kaz)
+		CString allTypesFilter;
+		for (unsigned int i = 0; i < list_ref.size(); ++i) {
+			allTypesFilter += list_ref[i].getType().pattern;
+			if (i < list_ref.size() - 1) {
+				allTypesFilter += ";";
+			}
+		}
+
+		// Add the item on top
+		// TODO: Make is translatable
+		typelist->addType(filetype_t("All supported types", allTypesFilter.GetBuffer()));
+	}
+
+	// Then add the supported types one by one
+	// TODO: Sort them alphabetically (have them sorted in m_typelists[key])
+	for ( unsigned int i = 0; i < list_ref.size(); ++i ) {
 		typelist->addType( list_ref[i].getType() );
+	}
 }
 private:
 struct filetype_copy_t


### PR DESCRIPTION
Like usual browse menu. Migrated "as-is" (just for the model browser for
now)

Should this change be available for all getTypeList calls?