### PR TITLE
Replace deprecated GDK_DISPLAY with gdk_x11_get_default_xdisplay

### DIFF
--- a/radiant/main.cpp
+++ b/radiant/main.cpp
@@ -861,7 +861,7 @@ int mainRadiant( int argc, char* argv[] ) {
 	}
 
 #if defined ( __linux__ ) || defined ( __APPLE__ )
-	if ( ( qglXQueryExtension == NULL ) || ( qglXQueryExtension( GDK_DISPLAY(),NULL,NULL ) != True ) ) {
+	if ( ( qglXQueryExtension == NULL ) || ( qglXQueryExtension( gdk_x11_get_default_xdisplay(), NULL, NULL ) != True ) ) {
 		Sys_FPrintf( SYS_ERR, "glXQueryExtension failed\n" );
 		_exit( 1 );
 		return 1;

--- a/radiant/mainframe.cpp
+++ b/radiant/mainframe.cpp
@@ -2200,12 +2200,12 @@ static void clipboard_clear( GtkClipboard *clipboard, gpointer user_data_or_owne
 static void clipboard_received( GtkClipboard *clipboard, GtkSelectionData *data, gpointer user_data ){
 	//g_Clipboard.SetLength( 0 );
 
-	if ( data->length < 0 ) {
+	if ( gtk_selection_data_get_length( data ) < 0 ) {
 		Sys_FPrintf( SYS_ERR, "Error retrieving selection\n" );
 	}
-	else if ( strcmp( gdk_atom_name( data->type ), clipboard_targets[0].target ) == 0 ) {
+	else if ( strcmp( gdk_atom_name( gtk_selection_data_get_data_type( data ) ), clipboard_targets[0].target ) == 0 ) {
 		g_Clipboard.SetLength( 0 );
-		g_Clipboard.Write( data->data, data->length );
+		g_Clipboard.Write( gtk_selection_data_get_data( data ), gtk_selection_data_get_length( data ) );
 	}
 
 	Clipboard_PasteMap();

--- a/radiant/qe3.cpp
+++ b/radiant/qe3.cpp
@@ -1212,25 +1212,25 @@ bool Sys_AltDown(){
 	char keys[32];
 	int x;
 
-	XQueryKeymap( GDK_DISPLAY(), keys );
+	XQueryKeymap( gdk_x11_get_default_xdisplay(), keys );
 
-	x = XKeysymToKeycode( GDK_DISPLAY(), XK_Alt_L );
+	x = XKeysymToKeycode( gdk_x11_get_default_xdisplay(), XK_Alt_L );
 	if ( keys[x / 8] & ( 1 << ( x % 8 ) ) ) {
 		return true;
 	}
 
-	x = XKeysymToKeycode( GDK_DISPLAY(), XK_Alt_R );
+	x = XKeysymToKeycode( gdk_x11_get_default_xdisplay(), XK_Alt_R );
 	if ( keys[x / 8] & ( 1 << ( x % 8 ) ) ) {
 		return true;
 	}
 
 	// For Apple, let users use their Command keys since Alt + X11 is hosed
-	x = XKeysymToKeycode( GDK_DISPLAY(), XK_Meta_L );
+	x = XKeysymToKeycode( gdk_x11_get_default_xdisplay(), XK_Meta_L );
 	if ( keys[x / 8] & ( 1 << ( x % 8 ) ) ) {
 		return true;
 	}
 
-	x = XKeysymToKeycode( GDK_DISPLAY(), XK_Meta_R );
+	x = XKeysymToKeycode( gdk_x11_get_default_xdisplay(), XK_Meta_R );
 	if ( keys[x / 8] & ( 1 << ( x % 8 ) ) ) {
 		return true;
 	}
@@ -1248,14 +1248,14 @@ bool Sys_ShiftDown(){
 	char keys[32];
 	int x;
 
-	XQueryKeymap( GDK_DISPLAY(), keys );
+	XQueryKeymap( gdk_x11_get_default_xdisplay(), keys );
 
-	x = XKeysymToKeycode( GDK_DISPLAY(), XK_Shift_L );
+	x = XKeysymToKeycode( gdk_x11_get_default_xdisplay(), XK_Shift_L );
 	if ( keys[x / 8] & ( 1 << ( x % 8 ) ) ) {
 		return true;
 	}
 
-	x = XKeysymToKeycode( GDK_DISPLAY(), XK_Shift_R );
+	x = XKeysymToKeycode( gdk_x11_get_default_xdisplay(), XK_Shift_R );
 	if ( keys[x / 8] & ( 1 << ( x % 8 ) ) ) {
 		return true;
 	}


### PR DESCRIPTION
See https://developer.gnome.org/gdk2/stable/gdk2-X-Window-System-Interaction.html#GDK-DISPLAY:CAPS
https://developer.gnome.org/gtk3/stable/gtk3-Selections.html#gtk-selection-data-get-data-type