### PR TITLE
Fix crash with too many patch planes

### DIFF
--- a/plugins/map/parse.cpp
+++ b/plugins/map/parse.cpp
@@ -212,8 +212,18 @@ void Patch_Parse( patchMesh_t *pPatch ){
 	// parse matrix dimensions
 	GetToken( false );
 	pPatch->width = atoi( token );
+	if ( pPatch->width > MAX_PATCH_WIDTH ) {
+		Syn_Printf( "ERROR: patch has too many planes, patch width > MAX_PATCH_WIDTH (%i > %i)\n", pPatch->width, MAX_PATCH_WIDTH );
+		pPatch->width = MAX_PATCH_WIDTH;
+		abortcode = MAP_ABORTED;
+	}
 	GetToken( false );
 	pPatch->height = atoi( token );
+	if ( pPatch->height > MAX_PATCH_HEIGHT ) {
+		Syn_Printf( "ERROR: patch has too many plane points, patch height > MAX_PATCH_HEIGHT (%i > %i)\n", pPatch->height, MAX_PATCH_HEIGHT );
+		pPatch->height = MAX_PATCH_HEIGHT;
+		abortcode = MAP_ABORTED;
+	}
 
 	// ignore contents/flags/value
 	GetToken( false );


### PR DESCRIPTION
This is fixing the crash but doesn't allow more than the limit.
Its quite some efford to get rid of the limits here:
https://github.com/TTimo/GtkRadiant/blob/master/include/qertypes.h#L421
https://github.com/TTimo/GtkRadiant/blob/master/include/qertypes.h#L433
https://github.com/TTimo/GtkRadiant/blob/master/include/qertypes.h#L435
https://github.com/TTimo/GtkRadiant/blob/master/include/qertypes.h#L347
Crash map file: https://gist.github.com/Pan7/4036387f81e728dfa033d2464fdde1fa
See https://github.com/TTimo/GtkRadiant/issues/517