### PR TITLE
Fix warning equality comparison with extraneous parentheses 2

### DIFF
--- a/libs/picomodel/pm_fm.c
+++ b/libs/picomodel/pm_fm.c
@@ -425,7 +425,7 @@ static picoModel_t *_fm_load( PM_PARAMS_LOAD ){
 #endif
 				continue;
 			}
-			else if ( ( p_index_LUT[triangle->index_xyz[j]].next == NULL ) ) { // Not equal to Main entry, and no LL entry
+			else if ( p_index_LUT[triangle->index_xyz[j]].next == NULL ) { // Not equal to Main entry, and no LL entry
 				// Add first entry of LL from Main
 				p_index_LUT2 = (index_LUT_t *)_pico_alloc( sizeof( index_LUT_t ) );
 				if ( p_index_LUT2 == NULL ) {

--- a/radiant/camwindow.cpp
+++ b/radiant/camwindow.cpp
@@ -127,7 +127,7 @@ rectangle_t rectangle_from_area_cam(){
 
 void update_xor_rectangle( XORRectangle& xor_rectangle ){
 	rectangle_t rectangle;
-	if ( ( g_qeglobals.d_select_mode == sel_area ) ) {
+	if ( g_qeglobals.d_select_mode == sel_area ) {
 		rectangle = rectangle_from_area_cam();
 	}
 	xor_rectangle.set( rectangle );


### PR DESCRIPTION
Fix for:
radiant/camwindow.cpp:130:35: warning: equality comparison with extraneous parentheses [-Wparentheses-equality]
        if ( ( g_qeglobals.d_select_mode == sel_area ) ) {
               ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
radiant/camwindow.cpp:130:35: note: remove extraneous parentheses around the comparison to silence this warning
        if ( ( g_qeglobals.d_select_mode == sel_area ) ) {
             ~~                          ^           ~~
radiant/camwindow.cpp:130:35: note: use '=' to turn this equality comparison into an assignment
        if ( ( g_qeglobals.d_select_mode == sel_area ) ) {
libs/picomodel/pm_fm.c:428:57: warning: equality comparison with extraneous parentheses [-Wparentheses-equality]
                        else if ( ( p_index_LUT[triangle->index_xyz[j]].next == NULL ) ) { // Not equal to Main entry, and no LL entry
                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
libs/picomodel/pm_fm.c:428:57: note: remove extraneous parentheses around the comparison to silence this warning
                        else if ( ( p_index_LUT[triangle->index_xyz[j]].next == NULL ) ) { // Not equal to Main entry, and no LL entry
                                  ~~                                         ^       ~~
libs/picomodel/pm_fm.c:428:57: note: use '=' to turn this equality comparison into an assignment
                        else if ( ( p_index_LUT[triangle->index_xyz[j]].next == NULL ) ) { // Not equal to Main entry, and no LL entry

See https://github.com/TTimo/GtkRadiant/issues/467