### PR TITLE
Fix warning comparison of unsigned expression < 0 is always false

### DIFF
--- a/plugins/model/cpicomodel.cpp
+++ b/plugins/model/cpicomodel.cpp
@@ -195,7 +195,7 @@ int CPicoModel::GetNumSurfaces( void ){
 }
 
 char *CPicoModel::GetShaderNameForSurface( const unsigned int surf ){
-	if ( !m_pModel || surf < 0 || surf >= m_children->len ) {
+	if ( !m_pModel || surf >= m_children->len ) {
 		return 0;
 	}
 


### PR DESCRIPTION
```
plugins/model/cpicomodel.cpp:198:25: warning: comparison of unsigned expression < 0 is always false [-Wtautological-compare]
        if ( !m_pModel || surf < 0 || surf >= m_children->len ) {
```
See https://github.com/TTimo/GtkRadiant/issues/467