### PR TITLE
Fix missing sentinel warning 2

### DIFF
--- a/contrib/camera/dialogs.cpp
+++ b/contrib/camera/dialogs.cpp
@@ -1202,7 +1202,7 @@ GtkWidget *CreateCameraInspectorDialog( void ){
 
 	renderer = gtk_cell_renderer_text_new();
 	//1 view column with the events
-	column = gtk_tree_view_column_new_with_attributes( "events", renderer, "text", EVENT_TEXT_COLUMN, NULL );
+	column = gtk_tree_view_column_new_with_attributes( "events", renderer, "text", EVENT_TEXT_COLUMN, (char*)NULL );
 	gtk_tree_view_append_column( GTK_TREE_VIEW( g_pEventsList ), column );
 
 	gtk_tree_view_set_headers_visible( GTK_TREE_VIEW( g_pEventsList ), FALSE );

--- a/contrib/prtview/LoadPortalFileDialog.cpp
+++ b/contrib/prtview/LoadPortalFileDialog.cpp
@@ -37,7 +37,7 @@ static void change_clicked( GtkWidget *widget, gpointer data ){
 	GtkFileChooserAction action = GTK_FILE_CHOOSER_ACTION_OPEN;
 
 	parent = GTK_WIDGET( data );
-	file_sel = gtk_file_chooser_dialog_new( _( "Locate portal (.prt) file" ), NULL, action, NULL, NULL );
+	file_sel = gtk_file_chooser_dialog_new( _( "Locate portal (.prt) file" ), NULL, action, NULL, (char*)NULL );
 	gtk_window_set_transient_for( GTK_WINDOW( file_sel ), GTK_WINDOW( parent ) );
 	gtk_dialog_add_button( GTK_DIALOG( file_sel ), _( "_Open" ), GTK_RESPONSE_ACCEPT );
 	gtk_dialog_add_button( GTK_DIALOG( file_sel ), _( "_Cancel" ), GTK_RESPONSE_CANCEL );


### PR DESCRIPTION
> contrib/camera/dialogs.cpp:1205:104: warning: missing sentinel in function call [-Wsentinel]
>         column = gtk_tree_view_column_new_with_attributes( "events", renderer, "text", EVENT_TEXT_COLUMN, NULL );
> contrib/prtview/LoadPortalFileDialog.cpp:40:100: warning: missing sentinel in function call [-Wsentinel]
>         file_sel = gtk_file_chooser_dialog_new( _( "Locate portal (.prt) file" ), NULL, action, NULL, NULL );
> 

See https://github.com/TTimo/GtkRadiant/issues/467