### PR TITLE
Fix xml passing to parameter warnings

### DIFF
--- a/tools/quake3/common/inout.c
+++ b/tools/quake3/common/inout.c
@@ -73,8 +73,8 @@ xmlNodePtr xml_NodeForVec( vec3_t v ){
 	char buf[1024];
 
 	sprintf( buf, "%f %f %f", v[0], v[1], v[2] );
-	ret = xmlNewNode( NULL, "point" );
-	xmlNodeSetContent( ret, buf );
+	ret = xmlNewNode( NULL, BAD_CAST "point" );
+	xmlNodeSetContent( ret, BAD_CAST buf );
 	return ret;
 }
 
@@ -151,15 +151,15 @@ void xml_Select( char *msg, int entitynum, int brushnum, qboolean bError ){
 
 	// now build a proper "select" XML node
 	sprintf( buf, "Entity %i, Brush %i: %s", entitynum, brushnum, msg );
-	node = xmlNewNode( NULL, "select" );
-	xmlNodeSetContent( node, buf );
+	node = xmlNewNode( NULL, BAD_CAST "select" );
+	xmlNodeSetContent( node, BAD_CAST buf );
 	level[0] = (int)'0' + ( bError ? SYS_ERR : SYS_WRN )  ;
 	level[1] = 0;
-	xmlSetProp( node, "level", (char *)&level );
+	xmlSetProp( node, BAD_CAST "level", BAD_CAST (char *)&level );
 	// a 'select' information
 	sprintf( buf, "%i %i", entitynum, brushnum );
-	select = xmlNewNode( NULL, "brush" );
-	xmlNodeSetContent( select, buf );
+	select = xmlNewNode( NULL, BAD_CAST "brush" );
+	xmlNodeSetContent( select, BAD_CAST buf );
 	xmlAddChild( node, select );
 	xml_SendNode( node );
 
@@ -178,15 +178,15 @@ void xml_Point( char *msg, vec3_t pt ){
 	char buf[1024];
 	char level[2];
 
-	node = xmlNewNode( NULL, "pointmsg" );
-	xmlNodeSetContent( node, msg );
+	node = xmlNewNode( NULL, BAD_CAST "pointmsg" );
+	xmlNodeSetContent( node, BAD_CAST msg );
 	level[0] = (int)'0' + SYS_ERR;
 	level[1] = 0;
-	xmlSetProp( node, "level", (char *)&level );
+	xmlSetProp( node, BAD_CAST "level", BAD_CAST (char *)&level );
 	// a 'point' node
 	sprintf( buf, "%g %g %g", pt[0], pt[1], pt[2] );
-	point = xmlNewNode( NULL, "point" );
-	xmlNodeSetContent( point, buf );
+	point = xmlNewNode( NULL, BAD_CAST "point" );
+	xmlNodeSetContent( point, BAD_CAST buf );
 	xmlAddChild( node, point );
 	xml_SendNode( node );
 
@@ -202,11 +202,11 @@ void xml_Winding( char *msg, vec3_t p[], int numpoints, qboolean die ){
 	char level[2];
 	int i;
 
-	node = xmlNewNode( NULL, "windingmsg" );
-	xmlNodeSetContent( node, msg );
+	node = xmlNewNode( NULL, BAD_CAST "windingmsg" );
+	xmlNodeSetContent( node, BAD_CAST msg );
 	level[0] = (int)'0' + SYS_ERR;
 	level[1] = 0;
-	xmlSetProp( node, "level", (char *)&level );
+	xmlSetProp( node, BAD_CAST "level", BAD_CAST (char *)&level );
 	// a 'winding' node
 	sprintf( buf, "%i ", numpoints );
 	for ( i = 0; i < numpoints; i++ )
@@ -219,8 +219,8 @@ void xml_Winding( char *msg, vec3_t p[], int numpoints, qboolean die ){
 		strcat( buf, smlbuf );
 	}
 
-	winding = xmlNewNode( NULL, "winding" );
-	xmlNodeSetContent( winding, buf );
+	winding = xmlNewNode( NULL, BAD_CAST "winding" );
+	xmlNodeSetContent( winding, BAD_CAST buf );
 	xmlAddChild( node, winding );
 	xml_SendNode( node );
 
@@ -284,19 +284,19 @@ void FPrintf( int flag, char *buf ){
 	 */
 	if ( !bGotXML ) {
 		// initialize
-		doc = xmlNewDoc( "1.0" );
-		doc->children = xmlNewDocRawNode( doc, NULL, "q3map_feedback", NULL );
+		doc = xmlNewDoc( BAD_CAST "1.0" );
+		doc->children = xmlNewDocRawNode( doc, NULL, BAD_CAST "q3map_feedback", NULL );
 		bGotXML = qtrue;
 	}
-	node = xmlNewNode( NULL, "message" );
+	node = xmlNewNode( NULL, BAD_CAST "message" );
 	{
 		gchar* utf8 = g_locale_to_utf8( buf, -1, NULL, NULL, NULL );
-		xmlNodeSetContent( node, utf8 );
+		xmlNodeSetContent( node, BAD_CAST utf8 );
 		g_free( utf8 );
 	}
 	level[0] = (int)'0' + flag;
 	level[1] = 0;
-	xmlSetProp( node, "level", (char *)&level );
+	xmlSetProp( node, BAD_CAST "level", BAD_CAST (char *)&level );
 
 	xml_SendNode( node );
 }

--- a/tools/quake3/q3map2/bsp.c
+++ b/tools/quake3/q3map2/bsp.c
@@ -347,12 +347,12 @@ void ProcessWorldModel( void ){
 		Sys_FPrintf( SYS_NOXML, "******* leaked *******\n" );
 		Sys_FPrintf( SYS_NOXML, "**********************\n" );
 		polyline = LeakFile( tree );
-		leaknode = xmlNewNode( NULL, "message" );
-		xmlNodeSetContent( leaknode, "MAP LEAKED\n" );
+		leaknode = xmlNewNode( NULL, BAD_CAST "message" );
+		xmlNodeSetContent( leaknode, BAD_CAST "MAP LEAKED\n" );
 		xmlAddChild( leaknode, polyline );
 		level[0] = (int) '0' + SYS_ERR;
 		level[1] = 0;
-		xmlSetProp( leaknode, "level", (char*) &level );
+		xmlSetProp( leaknode, BAD_CAST "level", BAD_CAST (char*) &level );
 		xml_SendNode( leaknode );
 		if ( leaktest ) {
 			Sys_Printf( "--- MAP LEAKED, ABORTING LEAKTEST ---\n" );

--- a/tools/quake3/q3map2/leakfile.c
+++ b/tools/quake3/q3map2/leakfile.c
@@ -82,7 +82,7 @@ xmlNodePtr LeakFile( tree_t *tree ){
 		Error( "Couldn't open %s\n", filename );
 	}
 
-	xml_node = xmlNewNode( NULL, "polyline" );
+	xml_node = xmlNewNode( NULL, BAD_CAST "polyline" );
 
 	count = 0;
 	node = &tree->outside_node;


### PR DESCRIPTION
> tools/quake3/common/inout.c:76:26: warning: passing 'char [6]' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>         ret = xmlNewNode( NULL, "point" );
>                                 ^~~~~~~
> /opt/local/include/libxml2/libxml/tree.h:838:22: note: passing argument to parameter 'name' here
>                                          const xmlChar *name);
>                                                         ^
> tools/quake3/common/inout.c:77:26: warning: passing 'char [1024]' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>         xmlNodeSetContent( ret, buf );
>                                 ^~~
> /opt/local/include/libxml2/libxml/tree.h:1061:22: note: passing argument to parameter 'content' here
>                                          const xmlChar *content);
>                                                         ^
> tools/quake3/common/inout.c:154:27: warning: passing 'char [7]' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>         node = xmlNewNode( NULL, "select" );
>                                  ^~~~~~~~
> /opt/local/include/libxml2/libxml/tree.h:838:22: note: passing argument to parameter 'name' here
>                                          const xmlChar *name);
>                                                         ^
> tools/quake3/common/inout.c:155:27: warning: passing 'char [1024]' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>         xmlNodeSetContent( node, buf );
>                                  ^~~
> /opt/local/include/libxml2/libxml/tree.h:1061:22: note: passing argument to parameter 'content' here
>                                          const xmlChar *content);
>                                                         ^
> tools/quake3/common/inout.c:158:20: warning: passing 'char [6]' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>         xmlSetProp( node, "level", (char *)&level );
>                           ^~~~~~~
> /opt/local/include/libxml2/libxml/tree.h:1016:22: note: passing argument to parameter 'name' here
>                                          const xmlChar *name,
>                                                         ^
> tools/quake3/common/inout.c:158:29: warning: passing 'char *' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>         xmlSetProp( node, "level", (char *)&level );
>                                    ^~~~~~~~~~~~~~
> /opt/local/include/libxml2/libxml/tree.h:1017:22: note: passing argument to parameter 'value' here
>                                          const xmlChar *value);
>                                                         ^
> tools/quake3/common/inout.c:161:29: warning: passing 'char [6]' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>         select = xmlNewNode( NULL, "brush" );
>                                    ^~~~~~~
> /opt/local/include/libxml2/libxml/tree.h:838:22: note: passing argument to parameter 'name' here
>                                          const xmlChar *name);
>                                                         ^
> tools/quake3/common/inout.c:162:29: warning: passing 'char [1024]' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>         xmlNodeSetContent( select, buf );
>                                    ^~~
> /opt/local/include/libxml2/libxml/tree.h:1061:22: note: passing argument to parameter 'content' here
>                                          const xmlChar *content);
>                                                         ^
> tools/quake3/common/inout.c:181:27: warning: passing 'char [9]' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>         node = xmlNewNode( NULL, "pointmsg" );
>                                  ^~~~~~~~~~
> /opt/local/include/libxml2/libxml/tree.h:838:22: note: passing argument to parameter 'name' here
>                                          const xmlChar *name);
>                                                         ^
> tools/quake3/common/inout.c:182:27: warning: passing 'char *' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>         xmlNodeSetContent( node, msg );
>                                  ^~~
> /opt/local/include/libxml2/libxml/tree.h:1061:22: note: passing argument to parameter 'content' here
>                                          const xmlChar *content);
>                                                         ^
> tools/quake3/common/inout.c:185:20: warning: passing 'char [6]' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>         xmlSetProp( node, "level", (char *)&level );
>                           ^~~~~~~
> /opt/local/include/libxml2/libxml/tree.h:1016:22: note: passing argument to parameter 'name' here
>                                          const xmlChar *name,
>                                                         ^
> tools/quake3/common/inout.c:185:29: warning: passing 'char *' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>         xmlSetProp( node, "level", (char *)&level );
>                                    ^~~~~~~~~~~~~~
> /opt/local/include/libxml2/libxml/tree.h:1017:22: note: passing argument to parameter 'value' here
>                                          const xmlChar *value);
>                                                         ^
> tools/quake3/common/inout.c:188:28: warning: passing 'char [6]' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>         point = xmlNewNode( NULL, "point" );
>                                   ^~~~~~~
> /opt/local/include/libxml2/libxml/tree.h:838:22: note: passing argument to parameter 'name' here
>                                          const xmlChar *name);
>                                                         ^
> tools/quake3/common/inout.c:189:28: warning: passing 'char [1024]' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>         xmlNodeSetContent( point, buf );
>                                   ^~~
> /opt/local/include/libxml2/libxml/tree.h:1061:22: note: passing argument to parameter 'content' here
>                                          const xmlChar *content);
>                                                         ^
> tools/quake3/common/inout.c:205:27: warning: passing 'char [11]' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>         node = xmlNewNode( NULL, "windingmsg" );
>                                  ^~~~~~~~~~~~
> /opt/local/include/libxml2/libxml/tree.h:838:22: note: passing argument to parameter 'name' here
>                                          const xmlChar *name);
>                                                         ^
> tools/quake3/common/inout.c:206:27: warning: passing 'char *' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>         xmlNodeSetContent( node, msg );
>                                  ^~~
> /opt/local/include/libxml2/libxml/tree.h:1061:22: note: passing argument to parameter 'content' here
>                                          const xmlChar *content);
>                                                         ^
> tools/quake3/common/inout.c:209:20: warning: passing 'char [6]' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>         xmlSetProp( node, "level", (char *)&level );
>                           ^~~~~~~
> /opt/local/include/libxml2/libxml/tree.h:1016:22: note: passing argument to parameter 'name' here
>                                          const xmlChar *name,
>                                                         ^
> tools/quake3/common/inout.c:209:29: warning: passing 'char *' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>         xmlSetProp( node, "level", (char *)&level );
>                                    ^~~~~~~~~~~~~~
> /opt/local/include/libxml2/libxml/tree.h:1017:22: note: passing argument to parameter 'value' here
>                                          const xmlChar *value);
>                                                         ^
> tools/quake3/common/inout.c:222:30: warning: passing 'char [8]' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>         winding = xmlNewNode( NULL, "winding" );
>                                     ^~~~~~~~~
> /opt/local/include/libxml2/libxml/tree.h:838:22: note: passing argument to parameter 'name' here
>                                          const xmlChar *name);
>                                                         ^
> tools/quake3/common/inout.c:223:30: warning: passing 'char [2048]' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>         xmlNodeSetContent( winding, buf );
>                                     ^~~
> /opt/local/include/libxml2/libxml/tree.h:1061:22: note: passing argument to parameter 'content' here
>                                          const xmlChar *content);
>                                                         ^
> tools/quake3/common/inout.c:287:20: warning: passing 'char [4]' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>                 doc = xmlNewDoc( "1.0" );
>                                  ^~~~~
> /opt/local/include/libxml2/libxml/tree.h:780:30: note: passing argument to parameter 'version' here
>                 xmlNewDoc               (const xmlChar *version);
>                                                         ^
> tools/quake3/common/inout.c:288:48: warning: passing 'char [15]' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>                 doc->children = xmlNewDocRawNode( doc, NULL, "q3map_feedback", NULL );
>                                                              ^~~~~~~~~~~~~~~~
> /opt/local/include/libxml2/libxml/tree.h:904:22: note: passing argument to parameter 'name' here
>                                          const xmlChar *name,
>                                                         ^
> tools/quake3/common/inout.c:291:27: warning: passing 'char [8]' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>         node = xmlNewNode( NULL, "message" );
>                                  ^~~~~~~~~
> /opt/local/include/libxml2/libxml/tree.h:838:22: note: passing argument to parameter 'name' here
>                                          const xmlChar *name);
>                                                         ^
> tools/quake3/common/inout.c:294:28: warning: passing 'gchar *' (aka 'char *') to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>                 xmlNodeSetContent( node, utf8 );
>                                          ^~~~
> /opt/local/include/libxml2/libxml/tree.h:1061:22: note: passing argument to parameter 'content' here
>                                          const xmlChar *content);
>                                                         ^
> tools/quake3/common/inout.c:299:20: warning: passing 'char [6]' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>         xmlSetProp( node, "level", (char *)&level );
>                           ^~~~~~~
> /opt/local/include/libxml2/libxml/tree.h:1016:22: note: passing argument to parameter 'name' here
>                                          const xmlChar *name,
>                                                         ^
> tools/quake3/common/inout.c:299:29: warning: passing 'char *' to parameter of type 'const xmlChar *' (aka 'const unsigned char *') converts between pointers to integer types with different sign [-Wpointer-sign]
>         xmlSetProp( node, "level", (char *)&level );
>                                    ^~~~~~~~~~~~~~
> /opt/local/include/libxml2/libxml/tree.h:1017:22: note: passing argument to parameter 'value' here
>                                          const xmlChar *value);
> 

See https://github.com/TTimo/GtkRadiant/issues/467