### PR TITLE
Fix warning variable add is used uninitialized

### DIFF
--- a/tools/quake3/q3map2/light.c
+++ b/tools/quake3/q3map2/light.c
@@ -973,6 +973,11 @@ int LightContributionToSample( trace_t *trace ){
 
 		/* return to sender */
 		return 1;
+	} 
+
+	/* unknown light type */
+	else {
+		return -1;
 	}
 
 	/* ydnar: changed to a variable number */


### PR DESCRIPTION
> tools/quake3/q3map2/light.c:939:12: warning: variable 'add' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
>         else if ( light->type == EMIT_SUN ) {
>                   ^~~~~~~~~~~~~~~~~~~~~~~
> tools/quake3/q3map2/light.c:979:7: note: uninitialized use occurs here
>         if ( add <= 0.0f || ( add <= light->falloffTolerance && ( light->flags & LIGHT_FAST_ACTUAL ) ) ) {
>              ^~~
> tools/quake3/q3map2/light.c:939:7: note: remove the 'if' if its condition is always true
>         else if ( light->type == EMIT_SUN ) {
>              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> tools/quake3/q3map2/light.c:754:11: note: initialize the variable 'add' to silence this warning
>         float add;
> 

See https://github.com/TTimo/GtkRadiant/issues/467