### PR TITLE
Fix warning the value of the size argument in strncat is too large

### DIFF
--- a/radiant/texwindow.cpp
+++ b/radiant/texwindow.cpp
@@ -581,7 +581,7 @@ void FillTextureList( GSList** pArray )
 		colon = strstr( (char*)l_shaderfiles->data, ":" );
 		if( colon )
 		{
-			strncat( shaderfile, colon, sizeof( shaderfile ) );
+			strncat( shaderfile, colon, sizeof( shaderfile ) - strlen( shaderfile ) - 1 );
 		}
 
 		for ( GSList *tmp = texdirs; tmp; tmp = g_slist_next( tmp ) )


### PR DESCRIPTION
> radiant/texwindow.cpp:584:32: warning: the value of the size argument in 'strncat' is too large, might lead to a buffer overflow [-Wstrncat-size]
>                         strncat( shaderfile, colon, sizeof( shaderfile ) );
>                                                     ^~~~~~~~~~~~~~~~~~~~
> radiant/texwindow.cpp:584:32: note: change the argument to be the free space in the destination buffer minus the terminating null byte
>                         strncat( shaderfile, colon, sizeof( shaderfile ) );
> 
See https://github.com/TTimo/GtkRadiant/issues/467