### PR TITLE
Fix warning implicit declaration of function

### DIFF
--- a/tools/quake3/q3data/p3dlib.c
+++ b/tools/quake3/q3data/p3dlib.c
@@ -19,6 +19,7 @@
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include "../common/cmdlib.h"
 #include "p3dlib.h"
 
 #ifdef WIN32


### PR DESCRIPTION
t

> ools/quake3/q3data/p3dlib.c:70:12: warning: implicit declaration of function 'Q_filelength' is invalid in C99 [-Wimplicit-function-declaration]
>         p3d.len = filelength( fileno( fp ) );
>                   ^
> tools/quake3/q3data/p3dlib.c:35:20: note: expanded from macro 'filelength'
> #define filelength Q_filelength
>                    ^
> tools/quake3/q3data/p3dlib.c:105:9: warning: implicit declaration of function 'Q_stricmp' is invalid in C99 [-Wimplicit-function-declaration]
>                 if ( !_strcmpi( s_token, name ) ) {
>                       ^
> tools/quake3/q3data/p3dlib.c:34:18: note: expanded from macro '_strcmpi'
> #define _strcmpi Q_stricmp
>                  ^
> 
See https://github.com/TTimo/GtkRadiant/issues/467