### PR TITLE
Fix warning g_strdown is deprecated

### DIFF
--- a/tools/quake3/common/vfs.c
+++ b/tools/quake3/common/vfs.c
@@ -145,7 +145,7 @@ static void vfsInitPakFile( const char *filename ){
 		g_pakFiles = g_slist_append( g_pakFiles, file );
 
 		vfsFixDOSName( filename_inzip );
-		g_strdown( filename_inzip );
+		g_ascii_strdown( filename_inzip, -1 );//-1 null terminated string
 
 		file->name = strdup( filename_inzip );
 		file->size = file_info.uncompressed_size;
@@ -236,7 +236,7 @@ int vfsGetFileCount( const char *filename ){
 
 	strcpy( fixed, filename );
 	vfsFixDOSName( fixed );
-	g_strdown( fixed );
+	g_ascii_strdown( fixed, -1 );
 
 	for ( lst = g_pakFiles; lst != NULL; lst = g_slist_next( lst ) )
 	{
@@ -296,7 +296,7 @@ int vfsLoadFile( const char *filename, void **bufferptr, int index ){
 	*bufferptr = NULL;
 	strcpy( fixed, filename );
 	vfsFixDOSName( fixed );
-	g_strdown( fixed );
+	g_ascii_strdown( fixed, -1 );
 
 	for ( i = 0; i < g_numDirs; i++ )
 	{


### PR DESCRIPTION
> tools/quake3/common/vfs.c:148:3: warning: 'g_strdown' is deprecated [-Wdeprecated-declarations]
>                 g_strdown( filename_inzip );
>                 ^
> /opt/local/include/glib-2.0/glib/gstrfuncs.h:207:23: note: 'g_strdown' has been explicitly marked deprecated here
> gchar*                g_strdown        (gchar       *string);
>                       ^
> tools/quake3/common/vfs.c:239:2: warning: 'g_strdown' is deprecated [-Wdeprecated-declarations]
>         g_strdown( fixed );
>         ^
> /opt/local/include/glib-2.0/glib/gstrfuncs.h:207:23: note: 'g_strdown' has been explicitly marked deprecated here
> gchar*                g_strdown        (gchar       *string);
>                       ^
> tools/quake3/common/vfs.c:299:2: warning: 'g_strdown' is deprecated [-Wdeprecated-declarations]
>         g_strdown( fixed );
>         ^
> /opt/local/include/glib-2.0/glib/gstrfuncs.h:207:23: note: 'g_strdown' has been explicitly marked deprecated here
> gchar*                g_strdown        (gchar       *string);
> 
See https://github.com/TTimo/GtkRadiant/issues/467
See https://developer.gnome.org/glib/stable/glib-String-Utility-Functions.html#g-ascii-strdown
There is also g_utf8_strdown that should considered be used in the future https://developer.gnome.org/glib/stable/glib-Unicode-Manipulation.html#g-utf8-strdown