### PR TITLE
pk3dir support (+pk4dir/dpkdir support)

### DIFF
--- a/plugins/vfspk3/vfs.cpp
+++ b/plugins/vfspk3/vfs.cpp
@@ -368,6 +368,8 @@ static int vfsPakSort( const void *a, const void *b ){
  */
 void vfsInitDirectory( const char *path ){
 	char filename[PATH_MAX];
+	const char* pak_ext = ".pk3";
+	const char* pakdir_suf = "dir";
 	GDir *dir;
 	GSList *dirlist = NULL;
 	int iGameMode; // 0: no filtering 1: SP 2: MP
@@ -413,7 +415,22 @@ void vfsInitDirectory( const char *path ){
 				}
 
 				char *ext = (char*)strrchr( name, '.' );
-				if ( ( ext == NULL ) || ( strcasecmp( ext, ".pk3" ) != 0 ) ) {
+				if ( ext == NULL ) {
+					continue;
+				}
+
+				gboolean is_pak = FALSE;
+
+				const char* cur_ext = pak_ext;
+				if ( strcasecmp( ext, cur_ext ) == 0 ) {
+					is_pak = TRUE;
+				}
+				cur_ext = g_strconcat(cur_ext, pakdir_suf, NULL);
+				if ( strcasecmp( ext, cur_ext ) == 0 ) {
+					is_pak = TRUE;
+				}
+
+				if ( !is_pak ) {
 					continue;
 				}
 
@@ -473,7 +490,11 @@ void vfsInitDirectory( const char *path ){
 				}
 
 				sprintf( filename, "%s/%s", path, name );
-				vfsInitPakFile( filename );
+				if ( g_str_has_suffix( name, "dir" ) ) {
+					vfsInitDirectory( filename );
+				} else {
+					vfsInitPakFile( filename );
+				}
 
 				g_free( name );
 				dirlist = g_slist_remove( cur, name );

--- a/plugins/vfspk3/vfs.cpp
+++ b/plugins/vfspk3/vfs.cpp
@@ -83,6 +83,9 @@ static char g_strDirs[VFS_MAXDIRS][PATH_MAX];
 static int g_numDirs;
 static bool g_bUsePak = true;
 
+// suported pak extension list
+const char* pak_ext_list[4] = { ".pk3", ".pk4", ".dpk", NULL };
+
 // =============================================================================
 // Static functions
 
@@ -368,7 +371,6 @@ static int vfsPakSort( const void *a, const void *b ){
  */
 void vfsInitDirectory( const char *path ){
 	char filename[PATH_MAX];
-	const char* pak_ext = ".pk3";
 	const char* pakdir_suf = "dir";
 	GDir *dir;
 	GSList *dirlist = NULL;
@@ -421,13 +423,15 @@ void vfsInitDirectory( const char *path ){
 
 				gboolean is_pak = FALSE;
 
-				const char* cur_ext = pak_ext;
-				if ( strcasecmp( ext, cur_ext ) == 0 ) {
-					is_pak = TRUE;
-				}
-				cur_ext = g_strconcat(cur_ext, pakdir_suf, NULL);
-				if ( strcasecmp( ext, cur_ext ) == 0 ) {
-					is_pak = TRUE;
+				for ( int i = 0; pak_ext_list[i] != NULL ; i++ ) {
+					const char* cur_ext = pak_ext_list[i];
+					if ( strcasecmp( ext, cur_ext ) == 0 ) {
+						is_pak = TRUE;
+					}
+					cur_ext = g_strconcat(cur_ext, pakdir_suf, NULL);
+					if ( strcasecmp( ext, cur_ext ) == 0 ) {
+						is_pak = TRUE;
+					}
 				}
 
 				if ( !is_pak ) {

--- a/plugins/vfspk3/vfs.h
+++ b/plugins/vfspk3/vfs.h
@@ -65,4 +65,7 @@ char* vfsExtractRelativePath( const char *in );
 // see ifilesystem.h for more notes
 char* vfsGetFullPath( const char*, int index = 0, int flag = 0 );
 
+// suported pak extension list
+extern const char* pak_ext_list[];
+
 #endif // _VFS_H_

--- a/plugins/vfspk3/vfs.h
+++ b/plugins/vfspk3/vfs.h
@@ -31,7 +31,7 @@
 #ifndef _VFS_H_
 #define _VFS_H_
 
-#define VFS_MAXDIRS 8
+#define VFS_MAXDIRS 64
 
 void vfsInitDirectory( const char *path );
 void vfsShutdown();

--- a/plugins/vfspk3/vfspk3.cpp
+++ b/plugins/vfspk3/vfspk3.cpp
@@ -67,7 +67,11 @@ extern "C" CSynapseClient * SYNAPSE_DLL_EXPORT Synapse_EnumerateInterfaces( cons
 	g_pSynapseServer->IncRef();
 	Set_Syn_Printf( g_pSynapseServer->Get_Syn_Printf() );
 
-	g_SynapseClient.AddAPI( VFS_MAJOR, "pk3", sizeof( _QERFileSystemTable ) );
+	for ( int i = 0; pak_ext_list[i] != NULL ; i++ ) {
+		// ".pk3" -> "pk3"
+		g_SynapseClient.AddAPI( VFS_MAJOR, pak_ext_list[i] + sizeof('.'), sizeof( _QERFileSystemTable ) );
+	}
+
 	g_SynapseClient.AddAPI( RADIANT_MAJOR, NULL, sizeof( _QERFuncTable_1 ), SYN_REQUIRE, &g_FuncTable );
 
 	return &g_SynapseClient;

--- a/tools/quake3/common/vfs.c
+++ b/tools/quake3/common/vfs.c
@@ -197,8 +197,21 @@ void vfsInitDirectory( const char *path ){
 				dirlist = g_strdup( name );
 
 				{
+
 					char *ext = strrchr( dirlist, '.' );
-					if ( ( ext == NULL ) || ( Q_stricmp( ext, ".pk3" ) != 0 ) ) {
+
+					if ( ext && ( !Q_stricmp( ext, ".pk3dir" ) || !Q_stricmp( ext, ".dpkdir" ) ) ) {
+						if ( g_numDirs == VFS_MAXDIRS ) {
+							continue;
+						}
+						snprintf( g_strDirs[g_numDirs], PATH_MAX, "%s/%s", path, name );
+						g_strDirs[g_numDirs][PATH_MAX] = '\0';
+						vfsFixDOSName( g_strDirs[g_numDirs] );
+						vfsAddSlash( g_strDirs[g_numDirs] );
+						++g_numDirs;
+					}
+
+					if ( ( ext == NULL ) || ( Q_stricmp( ext, ".pk3" ) != 0 || !Q_stricmp( ext, ".dpk" ) != 0 ) ) {
 						continue;
 					}
 				}

--- a/tools/quake3/common/vfs.h
+++ b/tools/quake3/common/vfs.h
@@ -31,7 +31,7 @@
 #ifndef _VFS_H_
 #define _VFS_H_
 
-#define VFS_MAXDIRS 8
+#define VFS_MAXDIRS 64
 
 void vfsInitDirectory( const char *path );
 void vfsShutdown();


### PR DESCRIPTION
This PR adds pk3dir support, in a simple way: each pk3dir is loaded as a VFS.

This PR also extends the pk3 VFS to support dpk/dpkdir for Dæmon engine/Unvanquished game, and I also added pk4/pk4dir because it was cheap.

I haven't yet found a way to not load found pk4 and dpk if VFS is pk3 only (or other combination), so the current code loads all pk3/pk4/dpk found if game profile uses pk3 VFS. It's probably not an issue though.

DPK vfs is the versionned and dependency based VFS used by the Dæmon engine (used by Unvanquished for example, see [DPK Format](http://wiki.unvanquished.net/index.php?title=DPK_Format)), this dpk support introduced by this PR does not handle versionning (it just loads all dpk/dpkdir available as if it was pk3), it does not prevent mapping and compiling, people just have to take care of concurrent paths like pk3 needs, and people are used to, so there is no urge to implement this versionning and dependency mechanism and it's considered out of topic regarding this PR.

The same mechanism was added to q3map2: pk3dir, dpk and dpkdir support added. I did not added pk4/pk4dir support since there is not pk4 based games known with map compilation needs. The pk3dir/dpk/dpkdir code is copypasted straight from NetRadiant tree, and also lacks versionning/dependency mechanism for dpk use case (it's true on NetRadiant side for q3map2 too).

I initially derivated my code from a code by @neumond, but I was not happy with this first implementation, or its latest state: this first implementation was just loading the pk3dir for the current map, and needed everything else (like texture set) being there as pk3. So I removed the per map pk3dir loading mechanism and added the “load every pk3dir found” mechanism instead. At the end, I discovered that all the code by @neumond was entirely removed, without any trace from it.