### PR TITLE
Q3data: Fix warning incompatible integer to pointer conversion passing

### DIFF
--- a/tools/quake3/q3data/md3lib.c
+++ b/tools/quake3/q3data/md3lib.c
@@ -149,8 +149,8 @@ void MD3_Dump( const char *filename ){
 		Error( "Unable to open '%s'\n", filename );
 	}
 
-	fileSize = filelength( fileno( fp ) );
-	_buffer = malloc( filelength( fileno( fp ) ) );
+	fileSize = filelength( fp );
+	_buffer = malloc( fileSize );
 	fread( _buffer, fileSize, 1, fp );
 	fclose( fp );
 


### PR DESCRIPTION
> tools/quake3/q3data/md3lib.c:152:25: warning: incompatible integer to pointer conversion passing 'int' to parameter of type 'FILE *' (aka 'struct __sFILE *') [-Wint-conversion]
>         fileSize = filelength( fileno( fp ) );
>                                ^~~~~~~~~~~~
> tools/quake3/q3data/../common/cmdlib.h:79:25: note: passing argument to parameter 'f' here
> int Q_filelength( FILE *f );
>                         ^
> tools/quake3/q3data/md3lib.c:153:32: warning: incompatible integer to pointer conversion passing 'int' to parameter of type 'FILE *' (aka 'struct __sFILE *') [-Wint-conversion]
>         _buffer = malloc( filelength( fileno( fp ) ) );
>                                       ^~~~~~~~~~~~
> tools/quake3/q3data/../common/cmdlib.h:79:25: note: passing argument to parameter 'f' here
> int Q_filelength( FILE *f );
>                         ^
> 

See https://github.com/TTimo/GtkRadiant/issues/467