### PR TITLE
Q3data: Fix warning variable shortestSide is used uninitialized

### DIFF
--- a/tools/quake3/q3data/md3lib.c
+++ b/tools/quake3/q3data/md3lib.c
@@ -82,6 +82,11 @@ void MD3_ComputeTagFromTri( md3Tag_t *pTag, const float pTri[3][3] ){
 		hypotSide = 2;
 		origin = 1;
 	}
+	else
+	{
+		Error( "invalid tag triangle, must be a right triangle with unequal length sides" );
+		return;
+	}
 	len[hypotSide] = -1;
 
 	if ( len[0] > len[1] && len[0] > len[2] ) {


### PR DESCRIPTION
> tools/quake3/q3data/md3lib.c:104:12: warning: variable 'shortestSide' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
>         else if ( len[2] > len[0] && len[2] > len[1] ) {
>                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> tools/quake3/q3data/md3lib.c:107:6: note: uninitialized use occurs here
>         len[shortestSide] = -1;
>             ^~~~~~~~~~~~
> tools/quake3/q3data/md3lib.c:104:7: note: remove the 'if' if its condition is always true
>         else if ( len[2] > len[0] && len[2] > len[1] ) {
>              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> tools/quake3/q3data/md3lib.c:104:12: warning: variable 'shortestSide' is used uninitialized whenever '&&' condition is false [-Wsometimes-uninitialized]
>         else if ( len[2] > len[0] && len[2] > len[1] ) {
>                   ^~~~~~~~~~~~~~~
> tools/quake3/q3data/md3lib.c:107:6: note: uninitialized use occurs here
>         len[shortestSide] = -1;
>             ^~~~~~~~~~~~

See https://github.com/TTimo/GtkRadiant/issues/467