### PR TITLE
Q3data: Fix warning format specifies type int but the argument has ty…

### DIFF
--- a/tools/quake3/q3data/video.c
+++ b/tools/quake3/q3data/video.c
@@ -1107,7 +1107,7 @@ void Cmd_Video( void ){
 
 	printf( "\n" );
 
-	printf( "Total size: %i\n", ftell( output ) );
+	printf( "Total size: %ld\n", ftell( output ) );
 	printf( "Average error: %f\n", sumError / ( frame - startframe ) );
 	printf( "Max error: %f\n", maxError );
 


### PR DESCRIPTION
…pe long

> tools/quake3/q3data/video.c:1110:30: warning: format specifies type 'int' but the argument has type 'long' [-Wformat]
>         printf( "Total size: %i\n", ftell( output ) );
> 

See https://github.com/TTimo/GtkRadiant/issues/467