### PR TITLE
Q3data: Fix warning variable psets is used uninitialized

### DIFF
--- a/tools/quake3/q3data/polyset.c
+++ b/tools/quake3/q3data/polyset.c
@@ -89,6 +89,7 @@ polyset_t *Polyset_LoadSets( const char *file, int *numpolysets, int maxTrisPerS
 	}
 	else{
 		Error( "TRI files no longer supported" );
+		return;
 	}
 //		TRI_LoadPolysets( file, &psets, numpolysets );
 


### PR DESCRIPTION
> tools/quake3/q3data/polyset.c:87:7: warning: variable 'psets' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
>         if ( strstr( file, ".3DS" ) || strstr( file, ".3ds" ) ) {
>              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> tools/quake3/q3data/polyset.c:112:34: note: uninitialized use occurs here
>         finalpsets = Polyset_SplitSets( psets, *numpolysets, numpolysets, maxTrisPerSet );
>                                         ^~~~~
> tools/quake3/q3data/polyset.c:87:2: note: remove the 'if' if its condition is always true
>         if ( strstr( file, ".3DS" ) || strstr( file, ".3ds" ) ) {
>         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
> tools/quake3/q3data/polyset.c:81:18: note: initialize the variable 'psets' to silence this warning
>         polyset_t *psets;
> 

See https://github.com/TTimo/GtkRadiant/issues/467