### PR TITLE
Fix warning variable bcHeight is used uninitialized

### DIFF
--- a/tools/quake3/common/imagelib.c
+++ b/tools/quake3/common/imagelib.c
@@ -755,6 +755,7 @@ void LoadBMP( const char *filename, byte **pic, byte **palette, int *width, int 
 	}
 	else {
 		Error( "%s had strange struct size", filename );
+		return;
 	}
 
 	if ( bcPlanes != 1 ) {


### PR DESCRIPTION
> tools/quake3/common/imagelib.c:737:12: warning: variable 'bcHeight' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
>         else if ( structSize == 12 ) {
>                   ^~~~~~~~~~~~~~~~
> tools/quake3/common/imagelib.c:768:7: note: uninitialized use occurs here
>         if ( bcHeight < 0 ) {
>              ^~~~~~~~
> tools/quake3/common/imagelib.c:737:7: note: remove the 'if' if its condition is always true
>         else if ( structSize == 12 ) {
>              ^~~~~~~~~~~~~~~~~~~~~~~~
> tools/quake3/common/imagelib.c:689:14: note: initialize the variable 'bcHeight' to silence this warning
>         int bcHeight;
>                     ^
>                      = 0
> tools/quake3/common/imagelib.c:737:12: warning: variable 'bcBitCount' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
>         else if ( structSize == 12 ) {
>                   ^~~~~~~~~~~~~~~~
> tools/quake3/common/imagelib.c:764:7: note: uninitialized use occurs here
>         if ( bcBitCount != 8 ) {
>              ^~~~~~~~~~
> tools/quake3/common/imagelib.c:737:7: note: remove the 'if' if its condition is always true
>         else if ( structSize == 12 ) {
>              ^~~~~~~~~~~~~~~~~~~~~~~~
> tools/quake3/common/imagelib.c:691:16: note: initialize the variable 'bcBitCount' to silence this warning
>         int bcBitCount;
>                       ^
>                        = 0
> tools/quake3/common/imagelib.c:737:12: warning: variable 'bcPlanes' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
>         else if ( structSize == 12 ) {
>                   ^~~~~~~~~~~~~~~~
> tools/quake3/common/imagelib.c:760:7: note: uninitialized use occurs here
>         if ( bcPlanes != 1 ) {
>              ^~~~~~~~
> tools/quake3/common/imagelib.c:737:7: note: remove the 'if' if its condition is always true
>         else if ( structSize == 12 ) {
>              ^~~~~~~~~~~~~~~~~~~~~~~~
> tools/quake3/common/imagelib.c:690:14: note: initialize the variable 'bcPlanes' to silence this warning
>         int bcPlanes;
>                     ^
>                      = 0
> 

See https://github.com/TTimo/GtkRadiant/issues/467