### PR TITLE
Q3data: Fix warning passing unsigned short * to parameter of type sho…

### DIFF
--- a/tools/quake3/q3data/3dslib.c
+++ b/tools/quake3/q3data/3dslib.c
@@ -47,7 +47,7 @@ static int ReadString( FILE *fp, char *buffer ){
 	return bytesRead;
 }
 
-static int ReadChunkAndLength( FILE *fp, short *chunk, long *len ){
+static int ReadChunkAndLength( FILE *fp, unsigned short *chunk, long *len ){
 	if ( fread( chunk, sizeof( short ), 1, fp ) != 1 ) {
 		return 0;
 	}

--- a/tools/quake3/q3data/polyset.c
+++ b/tools/quake3/q3data/polyset.c
@@ -89,7 +89,7 @@ polyset_t *Polyset_LoadSets( const char *file, int *numpolysets, int maxTrisPerS
 	}
 	else{
 		Error( "TRI files no longer supported" );
-		return;
+		return NULL;
 	}
 //		TRI_LoadPolysets( file, &psets, numpolysets );
 


### PR DESCRIPTION
…rt *

> tools/quake3/q3data/3dslib.c:65:34: warning: passing 'unsigned short *' to parameter of type 'short *' converts between pointers to integer types with different sign [-Wpointer-sign]
>         while ( ReadChunkAndLength( fp, &chunkID, &chunkLen ) )
>                                         ^~~~~~~~
> tools/quake3/q3data/3dslib.c:50:49: note: passing argument to parameter 'chunk' here
> static int ReadChunkAndLength( FILE *fp, short *chunk, long *len ){
>                                                 ^
> tools/quake3/q3data/3dslib.c:97:34: warning: passing 'unsigned short *' to parameter of type 'short *' converts between pointers to integer types with different sign [-Wpointer-sign]
>         while ( ReadChunkAndLength( fp, &chunkID, &chunkLen ) )
>                                         ^~~~~~~~
> tools/quake3/q3data/3dslib.c:50:49: note: passing argument to parameter 'chunk' here
> static int ReadChunkAndLength( FILE *fp, short *chunk, long *len ){
>                                                 ^
> tools/quake3/q3data/3dslib.c:246:34: warning: passing 'unsigned short *' to parameter of type 'short *' converts between pointers to integer types with different sign [-Wpointer-sign]
>         while ( ReadChunkAndLength( fp, &chunkID, &chunkLen ) )
>                                         ^~~~~~~~
> tools/quake3/q3data/3dslib.c:50:49: note: passing argument to parameter 'chunk' here
> static int ReadChunkAndLength( FILE *fp, short *chunk, long *len ){
>                                                 ^
> tools/quake3/q3data/3dslib.c:365:34: warning: passing 'unsigned short *' to parameter of type 'short *' converts between pointers to integer types with different sign [-Wpointer-sign]
>         while ( ReadChunkAndLength( fp, &chunkID, &chunkLen ) )
>                                         ^~~~~~~~
> tools/quake3/q3data/3dslib.c:50:49: note: passing argument to parameter 'chunk' here
> static int ReadChunkAndLength( FILE *fp, short *chunk, long *len ){
>                                                 ^
> tools/quake3/q3data/3dslib.c:410:34: warning: passing 'unsigned short *' to parameter of type 'short *' converts between pointers to integer types with different sign [-Wpointer-sign]
>         while ( ReadChunkAndLength( fp, &chunkID, &chunkLen ) )
>                                         ^~~~~~~~
> tools/quake3/q3data/3dslib.c:50:49: note: passing argument to parameter 'chunk' here
> static int ReadChunkAndLength( FILE *fp, short *chunk, long *len ){
>                                                 ^
> tools/quake3/q3data/3dslib.c:473:32: warning: passing 'unsigned short *' to parameter of type 'short *' converts between pointers to integer types with different sign [-Wpointer-sign]
>         if ( !ReadChunkAndLength( fp, &chunkID, &chunkLen ) ) {
>                                       ^~~~~~~~
> tools/quake3/q3data/3dslib.c:50:49: note: passing argument to parameter 'chunk' here
> static int ReadChunkAndLength( FILE *fp, short *chunk, long *len ){
>                                                 ^
> tools/quake3/q3data/3dslib.c:480:34: warning: passing 'unsigned short *' to parameter of type 'short *' converts between pointers to integer types with different sign [-Wpointer-sign]
>         while ( ReadChunkAndLength( fp, &chunkID, &chunkLen ) )
>                                         ^~~~~~~~
> tools/quake3/q3data/3dslib.c:50:49: note: passing argument to parameter 'chunk' here
> static int ReadChunkAndLength( FILE *fp, short *chunk, long *len ){
>                                                 ^
> 

See https://github.com/TTimo/GtkRadiant/issues/467