### PR TITLE
Q3data: Fix warning format %d expects argument of type int

### DIFF
--- a/tools/quake3/q3data/md3lib.c
+++ b/tools/quake3/q3data/md3lib.c
@@ -173,7 +173,7 @@ void MD3_Dump( const char *filename ){
 	printf( "  num tags:       %d\n", header.numTags );
 	printf( "  num surfaces:   %d\n", header.numSurfaces );
 	printf( "  num skins:      %d\n", header.numSkins );
-	printf( "  file size:      %d\n", fileSize );
+	printf( "  file size:      %ld\n", fileSize );
 
 	printf( "--- TAGS ---\n" );
 	pTag = ( md3Tag_t * ) ( ( ( char * ) buffer ) + header.ofsTags );


### PR DESCRIPTION
> tools/quake3/q3data/md3lib.c:176:10: warning: format '%d' expects argument of type 'int', but argument 2 has type 'long int' [-Wformat=]
>   printf( "  file size:      %d\n", fileSize );
> 

See https://github.com/TTimo/GtkRadiant/issues/467