### PR TITLE
Fix warning using floating point absolute value function fabs

### DIFF
--- a/plugins/textool/TexTool.cpp
+++ b/plugins/textool/TexTool.cpp
@@ -27,6 +27,7 @@
 //
 
 #include "StdAfx.h"
+#include <cmath>
 
 
 
@@ -260,19 +261,19 @@ void FitView( IWindow* hwndDlg, int TexSize[2] ){
 	}
 	// we want a texture with the same X / Y ratio
 	// compute XY space / window size ratio
-	float SSize = (float)fabs( g_2DView.m_Maxs[0] - g_2DView.m_Mins[0] );
-	float TSize = (float)fabs( g_2DView.m_Maxs[1] - g_2DView.m_Mins[1] );
+	float SSize = std::fabs( g_2DView.m_Maxs[0] - g_2DView.m_Mins[0] );
+	float TSize = std::fabs( g_2DView.m_Maxs[1] - g_2DView.m_Mins[1] );
 	float XSize = TexSize[0] * SSize;
 	float YSize = TexSize[1] * TSize;
-	float RatioX = XSize / (float)fabs( g_2DView.m_rect.left - g_2DView.m_rect.right );
-	float RatioY = YSize / (float)fabs( g_2DView.m_rect.top - g_2DView.m_rect.bottom );
+	float RatioX = XSize / std::fabs( g_2DView.m_rect.left - g_2DView.m_rect.right );
+	float RatioY = YSize / std::fabs( g_2DView.m_rect.top - g_2DView.m_rect.bottom );
 	if ( RatioX > RatioY ) {
-		YSize = (float)fabs( g_2DView.m_rect.top - g_2DView.m_rect.bottom ) * RatioX;
+		YSize = std::fabs( g_2DView.m_rect.top - g_2DView.m_rect.bottom ) * RatioX;
 		TSize = YSize / (float)TexSize[1];
 	}
 	else
 	{
-		XSize = (float)fabs( g_2DView.m_rect.left - g_2DView.m_rect.right ) * RatioY;
+		XSize = std::fabs( g_2DView.m_rect.left - g_2DView.m_rect.right ) * RatioY;
 		SSize = XSize / (float)TexSize[0];
 	}
 	g_2DView.m_Mins[0] = g_2DView.m_Center[0] - 0.5f * SSize;


### PR DESCRIPTION
> plugins/textool/TexTool.cpp:267:32: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
>         float RatioX = XSize / (float)fabs( g_2DView.m_rect.left - g_2DView.m_rect.right );
>                                       ^
> plugins/textool/TexTool.cpp:267:32: note: use function 'std::abs' instead
>         float RatioX = XSize / (float)fabs( g_2DView.m_rect.left - g_2DView.m_rect.right );
>                                       ^~~~
>                                       std::abs
> plugins/textool/TexTool.cpp:267:32: note: include the header <cstdlib> or explicitly provide a declaration for 'std::abs'
> plugins/textool/TexTool.cpp:268:32: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
>         float RatioY = YSize / (float)fabs( g_2DView.m_rect.top - g_2DView.m_rect.bottom );
>                                       ^
> plugins/textool/TexTool.cpp:268:32: note: use function 'std::abs' instead
>         float RatioY = YSize / (float)fabs( g_2DView.m_rect.top - g_2DView.m_rect.bottom );
>                                       ^~~~
>                                       std::abs
> plugins/textool/TexTool.cpp:268:32: note: include the header <cstdlib> or explicitly provide a declaration for 'std::abs'
> plugins/textool/TexTool.cpp:270:18: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
>                 YSize = (float)fabs( g_2DView.m_rect.top - g_2DView.m_rect.bottom ) * RatioX;
>                                ^
> plugins/textool/TexTool.cpp:270:18: note: use function 'std::abs' instead
>                 YSize = (float)fabs( g_2DView.m_rect.top - g_2DView.m_rect.bottom ) * RatioX;
>                                ^~~~
>                                std::abs
> plugins/textool/TexTool.cpp:270:18: note: include the header <cstdlib> or explicitly provide a declaration for 'std::abs'
> plugins/textool/TexTool.cpp:275:18: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
>                 XSize = (float)fabs( g_2DView.m_rect.left - g_2DView.m_rect.right ) * RatioY;
>                                ^
> plugins/textool/TexTool.cpp:275:18: note: use function 'std::abs' instead
>                 XSize = (float)fabs( g_2DView.m_rect.left - g_2DView.m_rect.right ) * RatioY;
>                                ^~~~
>                                std::abs
> 

See https://github.com/TTimo/GtkRadiant/issues/467
See http://en.cppreference.com/w/cpp/numeric/math/fabs