### PR TITLE
do not list empty shader/texture directories

### DIFF
--- a/include/ishaders.h
+++ b/include/ishaders.h
@@ -111,6 +111,9 @@ typedef void ( WINAPI * PFN_RELOADSHADERS )();
 // load all shaders in a given directory
 // this will scan the list of in-memory shaders, and load the related qtexture_t if needed
 typedef int ( WINAPI * PFN_LOADSHADERSFROMDIR )( const char* path );
+// count all shaders in a given directory
+// this will scan the list of in-memory shaders
+typedef bool ( WINAPI * PFN_ISDIRCONTAININGSHADER )( const char* path );
 // load a shader file (ie a set of shaders)
 // after LoadShaderFile shaders will be in memory, next step is to load the qtexture_t Radiant uses to represent them
 // if a shader with the same name exists, new one will not be loaded - don't use this to refresh the shaders!
@@ -178,6 +181,7 @@ struct _QERShadersTable
 	PFN_FREESHADERS m_pfnFreeShaders;
 	PFN_RELOADSHADERS m_pfnReloadShaders;
 	PFN_LOADSHADERSFROMDIR m_pfnLoadShadersFromDir;
+	PFN_ISDIRCONTAININGSHADER m_pfnIsDirContainingShaders;
 	PFN_LOADSHADERFILE m_pfnLoadShaderFile;
 	PFN_RELOADSHADERFILE m_pfnReloadShaderFile;
 	PFN_HASSHADER m_pfnHasShader;
@@ -219,7 +223,7 @@ struct _QERShadersTable
 #define QERApp_ColorShader_ForName __SHADERSTABLENAME.m_pfnColorShader_ForName
 #define QERApp_Shader_ForName_NoLoad __SHADERSTABLENAME.m_pfnShader_ForName_NoLoad
 #define QERApp_LoadShadersFromDir __SHADERSTABLENAME.m_pfnLoadShadersFromDir
-#define QERApp_LoadShadersFromDir __SHADERSTABLENAME.m_pfnLoadShadersFromDir
+#define QERApp_IsDirContainingShaders __SHADERSTABLENAME.m_pfnIsDirContainingShaders
 #define QERApp_CreateShader_ForTextureName __SHADERSTABLENAME.m_pfnCreateShader_ForTextureName
 #define QERApp_GetActiveShaderCount __SHADERSTABLENAME.m_pfnGetActiveShaderCount
 #define QERApp_ActiveShaders_SetDisplayed __SHADERSTABLENAME.m_pfnActiveShaders_SetDisplayed

--- a/plugins/shaders/shaders.cpp
+++ b/plugins/shaders/shaders.cpp
@@ -404,9 +404,20 @@ void WINAPI QERApp_ReloadShaders(){
 
 int WINAPI QERApp_LoadShadersFromDir( const char *path ){
 	int count = 0;
+
+	// some code adds a trailing slash
+	gchar* keyword = g_strdup(path);
+	if ( g_str_has_suffix( keyword, "/" ) ) {
+		keyword[ strlen(keyword) -1 ] = '\0';
+	}
+
+	gchar* around = g_strconcat("/", keyword, ".", NULL);
+	gchar* prefix = g_strconcat("textures/", keyword, "/", NULL);
+
 	// scan g_Shaders, and call QERApp_Shader_ForName for each in the given path
 	// this will load the texture if needed and will set it in use..
 	int nSize = g_Shaders.GetSize();
+
 	for ( int i = 0; i < nSize; i++ )
 	{
 		CShader *pShader = reinterpret_cast < CShader * >( g_Shaders[i] );
@@ -418,9 +429,7 @@ int WINAPI QERApp_LoadShadersFromDir( const char *path ){
 			continue;
 		}
 
-		// this is basically doing:
-		// if path in ["scripts/eerie.shader", "textures/eerie/blackness"]
-		if ( strstr( pShader->getShaderFileName(), path ) || strstr( pShader->getName(), path ) ) {
+		if ( strstr( pShader->getShaderFileName(), around ) != NULL || g_str_has_prefix( pShader->getName(), prefix ) ) {
 			count++;
 			// request the shader, this will load the texture if needed and set "inuse"
 			//++timo FIXME: should we put an Activate member on CShader?
@@ -437,6 +446,11 @@ int WINAPI QERApp_LoadShadersFromDir( const char *path ){
 #endif
 		}
 	}
+
+	g_free(keyword);
+	g_free(around);
+	g_free(prefix);
+
 	return count;
 }
 
@@ -446,7 +460,7 @@ bool WINAPI QERApp_IsDirContainingShaders( const char *path ){
 	// they will not be displayed and are not applicable to surfaces
 	// exclude shaders from other paths,
 	// they are not the ones we are looking for
-	gchar* prefix = g_strconcat("textures/", path, NULL);
+	gchar* prefix = g_strconcat("textures/", path, "/", NULL);
 	for ( int i = 0; i < nSize; i++ )
 	{
 		CShader *pShader = reinterpret_cast < CShader * >( g_Shaders[i] );

--- a/plugins/shaders/shaders.cpp
+++ b/plugins/shaders/shaders.cpp
@@ -429,6 +429,10 @@ int WINAPI QERApp_LoadShadersFromDir( const char *path ){
 			continue;
 		}
 
+		// - proceed if shader script base name is <path>
+		// for example: "scripts/eerie.shader" with "eerie" path
+		// - proceed if shader script base name is <path> and shader path starts with "textures/<path>"
+		// for example: "scripts/eerie.shader" providing "textures/eerie/blackness" with "eerie" path
 		if ( strstr( pShader->getShaderFileName(), around ) != NULL || g_str_has_prefix( pShader->getName(), prefix ) ) {
 			count++;
 #ifdef _DEBUG
@@ -467,6 +471,11 @@ bool WINAPI QERApp_IsDirContainingShaders( const char *path ){
 	for ( int i = 0; i < nSize; i++ )
 	{
 		CShader *pShader = reinterpret_cast < CShader * >( g_Shaders[i] );
+
+		// - returns true if shader script basename is <path> and shader path starts with "textures/"
+		// for example: "scripts/rockyvalley.shader" with "rockyvalley" path providing "textures/amethyst7/rockyvalley/rockyvalley_skybox/"
+		// - returns true if shader <path> startswith "textures/<path>"
+		// for example: "scripts/eerie.shader" with "eerie" path providing "textures/eerie/blackness"
 		if ( ( strstr( pShader->getShaderFileName(), around ) != NULL && g_str_has_prefix( pShader->getName(), "textures/" ) ) || g_str_has_prefix( pShader->getName(), prefix ) ) {
 			g_free(around);
 			g_free(prefix);

--- a/plugins/shaders/shaders.cpp
+++ b/plugins/shaders/shaders.cpp
@@ -460,15 +460,21 @@ bool WINAPI QERApp_IsDirContainingShaders( const char *path ){
 	// they will not be displayed and are not applicable to surfaces
 	// exclude shaders from other paths,
 	// they are not the ones we are looking for
+
+	gchar* around = g_strconcat("/", path, ".", NULL);
 	gchar* prefix = g_strconcat("textures/", path, "/", NULL);
+
 	for ( int i = 0; i < nSize; i++ )
 	{
 		CShader *pShader = reinterpret_cast < CShader * >( g_Shaders[i] );
-		if ( g_str_has_prefix( pShader->getName(), prefix ) ) {
+		if ( ( strstr( pShader->getShaderFileName(), around ) != NULL && g_str_has_prefix( pShader->getName(), "textures/" ) ) || g_str_has_prefix( pShader->getName(), prefix ) ) {
+			g_free(around);
 			g_free(prefix);
 			return true;
 		}
 	}
+
+	g_free(around);
 	g_free(prefix);
 	return false;
 }

--- a/plugins/shaders/shaders.cpp
+++ b/plugins/shaders/shaders.cpp
@@ -431,18 +431,18 @@ int WINAPI QERApp_LoadShadersFromDir( const char *path ){
 
 		if ( strstr( pShader->getShaderFileName(), around ) != NULL || g_str_has_prefix( pShader->getName(), prefix ) ) {
 			count++;
+#ifdef _DEBUG
 			// request the shader, this will load the texture if needed and set "inuse"
 			//++timo FIXME: should we put an Activate member on CShader?
 			// this QERApp_Shader_ForName call is a kind of hack
 			IShader *pFoo = QERApp_Shader_ForName( pShader->getName() );
-#ifdef _DEBUG
 			// check we activated the right shader
 			// NOTE: if there was something else loaded, the size of g_Shaders may have changed and strange behaviours are to be expected
 			if ( pFoo != pShader ) {
 				Sys_FPrintf( SYS_WRN, "WARNING: unexpected pFoo != pShader in QERApp_LoadShadersFromDir\n" );
 			}
 #else
-			pFoo = NULL; // leo: shut up the compiler
+			QERApp_Shader_ForName( pShader->getName() );
 #endif
 		}
 	}

--- a/radiant/mainframe.cpp
+++ b/radiant/mainframe.cpp
@@ -552,6 +552,7 @@ gint HandleCommand( GtkWidget *widget, gpointer data ){
 		  case ID_TEXTURES_LOAD: g_pParentWnd->OnTexturesLoad(); break;
 		  case ID_TEXTURES_RELOADSHADERS: g_pParentWnd->OnTexturesReloadshaders(); break;
 		  case ID_TEXTURES_SHADERS_SHOW: g_pParentWnd->OnTexturesShadersShow(); break;
+		  case ID_TEXTURES_EMPTYDIRS_HIDE: g_pParentWnd->OnTexturesEmptyDirsHide(); break;
 		  case ID_TEXTURES_TEXTUREWINDOWSCALE_200:
 		  case ID_TEXTURES_TEXTUREWINDOWSCALE_100:
 		  case ID_TEXTURES_TEXTUREWINDOWSCALE_50:
@@ -1401,6 +1402,9 @@ void MainFrame::create_main_menu( GtkWidget *window, GtkWidget *vbox ){
 	item = create_check_menu_item_with_mnemonic( menu, _( "shaderlist.txt only" ),
 												 G_CALLBACK( HandleCommand ), ID_TEXTURES_SHADERLISTONLY, FALSE );
 	g_object_set_data( G_OBJECT( window ), "menu_textures_shaderlistonly", item );
+	item = create_check_menu_item_with_mnemonic( menu, _( "Hide empty directories" ),
+												 G_CALLBACK( HandleCommand ), ID_TEXTURES_EMPTYDIRS_HIDE, FALSE );
+	g_object_set_data( G_OBJECT( window ), "menu_textures_emptydirs_hide", item );
 	item = menu_separator( menu );
 
 	menu_in_menu = create_menu_in_menu_with_mnemonic( menu, _( "Texture Directories" ) );
@@ -3107,6 +3111,8 @@ void MainFrame::Create(){
 	g_bIgnoreCommands++;
 	item = GTK_WIDGET( g_object_get_data( G_OBJECT( m_pWidget ), "menu_textures_shaders_show" ) );
 	gtk_check_menu_item_set_active( GTK_CHECK_MENU_ITEM( item ), g_PrefsDlg.m_bShowShaders ? TRUE : FALSE );
+	item = GTK_WIDGET( g_object_get_data( G_OBJECT( m_pWidget ), "menu_textures_emptydirs_hide" ) );
+	gtk_check_menu_item_set_active( GTK_CHECK_MENU_ITEM( item ), g_PrefsDlg.m_bHideEmptyDirs ? TRUE : FALSE );
 	item = GTK_WIDGET( g_object_get_data( G_OBJECT( m_pWidget ), "menu_textures_shaderlistonly" ) );
 	gtk_check_menu_item_set_active( GTK_CHECK_MENU_ITEM( item ), g_PrefsDlg.m_bTexturesShaderlistOnly ? TRUE : FALSE );
 	g_bIgnoreCommands--;
@@ -5942,6 +5948,20 @@ void MainFrame::OnTexturesReloadshaders(){
 	Texture_SetTexture( &g_qeglobals.d_texturewin.texdef, &g_qeglobals.d_texturewin.brushprimit_texdef, false, NULL, false );
 	Sys_UpdateWindows( W_ALL );
 	Sys_EndWait();
+
+	GSList *texdirs = NULL;
+	FillTextureList( &texdirs );
+	FillTextureMenu( texdirs );
+	FillTextureDirListWidget( texdirs );
+	ClearGSList( texdirs );
+}
+
+void MainFrame::OnTexturesEmptyDirsHide(){
+	g_PrefsDlg.m_bHideEmptyDirs ^= 1;
+	GtkWidget *item = GTK_WIDGET( g_object_get_data( G_OBJECT( m_pWidget ), "menu_textures_emptydirs_hide" ) );
+	g_bIgnoreCommands++;
+	gtk_check_menu_item_set_active( GTK_CHECK_MENU_ITEM( item ), g_PrefsDlg.m_bHideEmptyDirs ? TRUE : FALSE );
+	g_bIgnoreCommands--;
 
 	GSList *texdirs = NULL;
 	FillTextureList( &texdirs );

--- a/radiant/mainframe.h
+++ b/radiant/mainframe.h
@@ -216,6 +216,7 @@ struct SKeyInfo
 #define ID_VIEW_HIDESHOW_SHOWHIDDEN     33007
 #define ID_TEXTURES_SHADERS_SHOW        33008
 //#define ID_SELECTION_CSGADD             33009
+#define ID_TEXTURES_EMPTYDIRS_HIDE      33010
 #define ID_SELECTION_CSGMERGE           33011
 #define ID_TEXTURES_FLUSH_UNUSED        33014
 #define ID_DROP_GROUP_REMOVE            33016
@@ -863,6 +864,7 @@ void OnViewCrosshair();
 void OnViewHideshowHideselected();
 void OnViewHideshowShowhidden();
 void OnTexturesShadersShow();
+void OnTexturesEmptyDirsHide();
 void OnViewGroups();
 void OnDropGroupAddtoWorld();
 void OnDropGroupName();

--- a/radiant/preferences.cpp
+++ b/radiant/preferences.cpp
@@ -119,6 +119,7 @@
 #define TEXTURESUBSET_KEY         "UseTextureSubsetLoading"
 #define TEXTUREQUALITY_KEY      "TextureQuality"
 #define SHOWSHADERS_KEY           "ShowShaders"
+#define HIDEEMPTYDIRS_KEY       "HideEmptyDirs"
 #define SHADERTEST_KEY          "ShaderTest"
 #define GLLIGHTING_KEY          "UseGLLighting"
 #define LOADSHADERS_KEY         "LoadShaders"
@@ -644,6 +645,7 @@ PrefsDlg::PrefsDlg (){
 	m_bSelectWholeEntities = TRUE;
 	m_nTextureQuality = 3;
 	m_bShowShaders = TRUE;
+	m_bHideEmptyDirs = FALSE;
 	m_bGLLighting = FALSE;
 	m_nShader = 0;
 	m_nUndoLevels = 30;
@@ -3076,6 +3078,7 @@ void PrefsDlg::LoadPrefs(){
 	mLocalPrefs.GetPref( SWITCHCLIP_KEY,         &m_bSwitchClip,                 TRUE );
 	mLocalPrefs.GetPref( SELWHOLEENTS_KEY,       &m_bSelectWholeEntities,        TRUE );
 	mLocalPrefs.GetPref( SHOWSHADERS_KEY,        &m_bShowShaders,                TRUE );
+	mLocalPrefs.GetPref( HIDEEMPTYDIRS_KEY,      &m_bHideEmptyDirs,              FALSE );
 	mLocalPrefs.GetPref( GLLIGHTING_KEY,         &m_bGLLighting,                 FALSE );
 	mLocalPrefs.GetPref( NOSTIPPLE_KEY,          &m_bNoStipple,                  FALSE );
 	mLocalPrefs.GetPref( UNDOLEVELS_KEY,         &m_nUndoLevels,                 30 );

--- a/radiant/preferences.h
+++ b/radiant/preferences.h
@@ -636,6 +636,7 @@ bool m_bTextureScrollbar;
 bool m_bDisplayLists;
 bool m_bAntialiasedPointsAndLines;    // Fishman - Add antialiazed points and lines support. 09/03/00
 bool m_bShowShaders;
+bool m_bHideEmptyDirs;
 int m_nShader;
 bool m_bNoStipple;
 int m_nUndoLevels;

--- a/radiant/texwindow.cpp
+++ b/radiant/texwindow.cpp
@@ -525,10 +525,48 @@ void BuildShaderList(){
 	}
 }
 
+bool IsValidTextureName(char* name){
+	CString strTemp;
+
+	StripExtension( name );
+	strTemp = name;
+	strTemp.MakeLower();
+
+	// avoid effect textures for Q3 texture sets
+	if ( strTemp.Find( ".specular" ) >= 0 ||
+		strTemp.Find( ".glow" ) >= 0 ||
+		strTemp.Find( ".bump" ) >= 0 ||
+		strTemp.Find( ".diffuse" ) >= 0 ||
+		strTemp.Find( ".blend" ) >= 0 ||
+		strTemp.Find( ".alpha" ) >= 0 ) {
+		return false;
+	}
+
+	// avoid glow, heightmap, normalmap and specular maps for Q4 texture sets
+	if ( g_str_has_suffix( name, "_g" ) ||
+			g_str_has_suffix( name, "_h" ) ||
+			g_str_has_suffix( name, "_local" ) ||
+			g_str_has_suffix( name, "_nm" ) ||
+			g_str_has_suffix( name, "_s" ) ||
+			g_str_has_suffix( name, "_bump" ) ||
+			g_str_has_suffix( name, "_gloss" ) ||
+			g_str_has_suffix( name, "_luma" ) ||
+			g_str_has_suffix( name, "_norm" ) ) {
+		return false;
+	}
+
+	// avoid ever loading a texture name with spaces
+	if ( strTemp.Find( " " ) >= 0 ) {
+		Sys_FPrintf( SYS_WRN, "WARNING: Skipping texture name with spaces [%s]\n", strTemp.GetBuffer() );
+		return false;
+	}
+
+	return true;
+}
+
 void Texture_ListDirectory(){
 	char name[1024];
 	char dirstring[1024];
-	CString strTemp;
 	int shaders_count = 0;
 	int textures_count = 0;
 	GSList *files = NULL, *temp;
@@ -558,36 +596,7 @@ void Texture_ListDirectory(){
 	{
 		sprintf( name, "%s%s", texture_directory, (char*)temp->data );
 
-		StripExtension( name );
-		strTemp = name;
-		strTemp.MakeLower();
-
-		// avoid effect textures for Q3 texture sets
-		if ( strTemp.Find( ".specular" ) >= 0 ||
-			 strTemp.Find( ".glow" ) >= 0 ||
-			 strTemp.Find( ".bump" ) >= 0 ||
-			 strTemp.Find( ".diffuse" ) >= 0 ||
-			 strTemp.Find( ".blend" ) >= 0 ||
-			 strTemp.Find( ".alpha" ) >= 0 ) {
-			continue;
-		}
-
-		// avoid glow, heightmap, normalmap and specular maps for Q4 texture sets
-		if ( g_str_has_suffix( name, "_g" ) ||
-				g_str_has_suffix( name, "_h" ) ||
-				g_str_has_suffix( name, "_local" ) ||
-				g_str_has_suffix( name, "_nm" ) ||
-				g_str_has_suffix( name, "_s" ) ||
-				g_str_has_suffix( name, "_bump" ) ||
-				g_str_has_suffix( name, "_gloss" ) ||
-				g_str_has_suffix( name, "_luma" ) ||
-				g_str_has_suffix( name, "_norm" ) ) {
-			continue;
-		}
-
-		// avoid ever loading a texture name with spaces
-		if ( strTemp.Find( " " ) >= 0 ) {
-			Sys_FPrintf( SYS_WRN, "WARNING: Skipping texture name with spaces [%s]\n", strTemp.GetBuffer() );
+		if ( !IsValidTextureName( name ) ) {
 			continue;
 		}
 

--- a/radiant/texwindow.cpp
+++ b/radiant/texwindow.cpp
@@ -685,6 +685,10 @@ void FillTextureList( GSList** pArray )
 			{
 				texdirs = g_slist_append( texdirs, g_strdup( (char *)p->data ) );
 			}
+			else
+			{
+				Sys_Printf( "Hiding empty texture dir: %s\n", g_strdup( (char *)p->data ) );
+			}
 		}
 		vfsClearFileDirList( &texdirs_tmp );
 	}
@@ -722,6 +726,10 @@ void FillTextureList( GSList** pArray )
 			if( !g_PrefsDlg.m_bHideEmptyDirs || QERApp_IsDirContainingShaders( shaderfile ) )
 			{
 				texdirs = g_slist_prepend( texdirs, g_strdup( shaderfile ) );
+			}
+			else
+			{
+				Sys_Printf( "Hiding empty shader dir: %s\n", g_strdup ( shaderfile ) );
 			}
 		}
 

--- a/radiant/texwindow.cpp
+++ b/radiant/texwindow.cpp
@@ -681,7 +681,7 @@ void FillTextureList( GSList** pArray )
 			// Hydra: erm, this didn't used to do anything except leak memory...
 			// For Halflife support this is required to work however.
 			// g_slist_append(texdirs, p->data);
-			if ( IsDirContainingTextures( (char*)p->data ) )
+			if ( !g_PrefsDlg.m_bHideEmptyDirs || IsDirContainingTextures( (char*)p->data ) )
 			{
 				texdirs = g_slist_append( texdirs, g_strdup( (char *)p->data ) );
 			}
@@ -719,7 +719,7 @@ void FillTextureList( GSList** pArray )
 		}
 
 		if ( !found ) {
-			if( QERApp_IsDirContainingShaders( shaderfile ) )
+			if( !g_PrefsDlg.m_bHideEmptyDirs || QERApp_IsDirContainingShaders( shaderfile ) )
 			{
 				texdirs = g_slist_prepend( texdirs, g_strdup( shaderfile ) );
 			}

--- a/radiant/texwindow.cpp
+++ b/radiant/texwindow.cpp
@@ -564,6 +564,33 @@ bool IsValidTextureName(char* name){
 	return true;
 }
 
+bool IsDirContainingTextures(const char* path){
+	char name[1024];
+	char dirstring[1024];
+	GSList *files = NULL, *temp;
+
+	sprintf( dirstring, "textures/%s", path );
+	g_ImageManager.BeginExtensionsScan();
+	const char* ext;
+	while ( ( ext = g_ImageManager.GetNextExtension() ) != NULL )
+	{
+		files = g_slist_concat( files, vfsGetFileList( dirstring, ext ) );
+	}
+
+	for ( temp = files; temp; temp = temp->next )
+	{
+		sprintf( name, "%s", (char*)temp->data );
+
+		if ( IsValidTextureName( name ) ) {
+			vfsClearFileDirList( &files );
+			return true;
+		}
+	}
+
+	vfsClearFileDirList( &files );
+	return false;
+}
+
 void Texture_ListDirectory(){
 	char name[1024];
 	char dirstring[1024];
@@ -649,7 +676,10 @@ void FillTextureList( GSList** pArray )
 			// Hydra: erm, this didn't used to do anything except leak memory...
 			// For Halflife support this is required to work however.
 			// g_slist_append(texdirs, p->data);
-			texdirs = g_slist_append( texdirs, g_strdup( (char *)p->data ) );
+			if ( IsDirContainingTextures( (char*)p->data ) )
+			{
+				texdirs = g_slist_append( texdirs, g_strdup( (char *)p->data ) );
+			}
 		}
 		vfsClearFileDirList( &texdirs_tmp );
 	}

--- a/radiant/texwindow.cpp
+++ b/radiant/texwindow.cpp
@@ -542,8 +542,8 @@ bool IsValidTextureName(char* name){
 		return false;
 	}
 
-	// avoid glow, heightmap, normalmap and specular maps for Q4 texture sets
 	if ( g_str_has_suffix( name, "_g" ) ||
+			// avoid glow, heightmap, normalmap and specular maps for Q4 texture sets
 			g_str_has_suffix( name, "_h" ) ||
 			g_str_has_suffix( name, "_local" ) ||
 			g_str_has_suffix( name, "_nm" ) ||
@@ -551,7 +551,12 @@ bool IsValidTextureName(char* name){
 			g_str_has_suffix( name, "_bump" ) ||
 			g_str_has_suffix( name, "_gloss" ) ||
 			g_str_has_suffix( name, "_luma" ) ||
-			g_str_has_suffix( name, "_norm" ) ) {
+			g_str_has_suffix( name, "_norm" ) ||
+			// more well-known suffixes
+			g_str_has_suffix( name, "_p" ) || // preview (used by qer_editorimage)
+			g_str_has_suffix( name, "_g" ) || // gloss
+			g_str_has_suffix( name, "_n" )    // normal
+			) {
 		return false;
 	}
 

--- a/radiant/texwindow.cpp
+++ b/radiant/texwindow.cpp
@@ -711,10 +711,12 @@ void FillTextureList( GSList** pArray )
 		}
 
 		for ( GSList *tmp = texdirs; tmp; tmp = g_slist_next( tmp ) )
+		{
 			if ( !strcasecmp( (char*)tmp->data, shaderfile ) ) {
 				found = TRUE;
 				break;
 			}
+		}
 
 		if ( !found ) {
 			if( QERApp_IsDirContainingShaders( shaderfile ) )

--- a/radiant/texwindow.cpp
+++ b/radiant/texwindow.cpp
@@ -591,7 +591,10 @@ void FillTextureList( GSList** pArray )
 			}
 
 		if ( !found ) {
-			texdirs = g_slist_prepend( texdirs, g_strdup( shaderfile ) );
+			if( QERApp_IsDirContainingShaders( shaderfile ) )
+			{
+				texdirs = g_slist_prepend( texdirs, g_strdup( shaderfile ) );
+			}
 		}
 
 		free( l_shaderfiles->data );
@@ -784,6 +787,7 @@ void Texture_ShowDirectory_by_path( const char* pPath )
    ( the GL textures are not flushed though)
    ==============
  */
+
 void Texture_ShowDirectory(){
 	char name[1024];
 	char dirstring[1024];


### PR DESCRIPTION
Previously, GtkRadiant was displaying a directory for every shader or texture dirname even if there was no existing shader neither texture using this dirname. The first case happens for example when a name is provided in shaderlist but no shader script is there, the second case happens when a texture directory only contains invalid files like unknown formats or blacklisted suffixes (gloss, specular etc.).

This code adds two functions to know if a shader dirname or texture dirname contains nothing and obviously use them.

Some already existing code was moved in some new functions, for example the texture name validation code was moved to a dedicated function, used two times: when looking for non empty directories, or when loading current displayed directories.

I added some more well-known forbidden prefixes (for gloss and normal maps and preview images).

One obvious warning was fixed (complaining about unused affectation because the affected value was only used in debug build).

I also improved the shader dir checking, before  it was doing something like that:

```python3
if path in ["scripts/eerie.shader", "textures/eerie/blackness"]
```

now it's doing something like that:

```python3
if "/" + path + "." in "scripts/eerie.shader" or "textures/eerie/blackness".startswith("textures/" + path)
```

Also, I fixed the recognition of "eerie" in "scripts/eerie.shader" since the function was receiving it as "eerie/" leading to "eerie/.shader" look out.

Previously, GtkRadiant was still loading unapplicable shaders (those not starting with "textures/" prefixes) even if they were never displayed in menu or texture browser, that's now fixed.

There is one known bug but it's not a regression so it must not prevent merging: if a texture dir contains a preview image for a shader name in a shader dir with a different name than the texture dir name, the texture dir name will be displayed but the preview image will not since being known as a preview image, leading to the only one case where an empty directory can still be listed.