### PR TITLE
gcc8: static_cast NULL instead of reinterpret_cast

### DIFF
--- a/libs/splines/util_str.cpp
+++ b/libs/splines/util_str.cpp
@@ -480,7 +480,7 @@ void TestStringClass
 	idStr b;                                // b.len == 0, b.data == "\0"
 	idStr c( "test" );                  // c.len == 4, c.data == "test\0"
 	idStr d( c );                       // d.len == 4, d.data == "test\0"
-	idStr e( reinterpret_cast<const char *>( NULL ) );
+	idStr e( static_cast<const char *>( NULL ) );
 	// e.len == 0, e.data == "\0"					ASSERT!
 	int i;                              // i == ?
 
@@ -499,14 +499,14 @@ void TestStringClass
 	a = NULL;                           // a.len == 0, a.data == "\0"					ASSERT!
 	a = c + d;                          // a.len == 8, a.data == "testtest\0"
 	a = c + "wow";                      // a.len == 7, a.data == "testwow\0"
-	a = c + reinterpret_cast<const char *>( NULL );
+	a = c + static_cast<const char *>( NULL );
 	// a.len == 4, a.data == "test\0"			ASSERT!
 	a = "this" + d;                 // a.len == 8, a.data == "thistest\0"
-	a = reinterpret_cast<const char *>( NULL ) + d;
+	a = static_cast<const char *>( NULL ) + d;
 	// a.len == 4, a.data == "test\0"			ASSERT!
 	a += c;                             // a.len == 8, a.data == "testtest\0"
 	a += "wow";                         // a.len == 11, a.data == "testtestwow\0"
-	a += reinterpret_cast<const char *>( NULL );
+	a += static_cast<const char *>( NULL );
 	// a.len == 11, a.data == "testtestwow\0"	ASSERT!
 
 	a = "test";                         // a.len == 4, a.data == "test\0"


### PR DESCRIPTION
Compiling with GCC  8 I got these errors:

```gcc
g++ -o build/release/shobjs/libs/splines/util_str.os -c -pipe -Wall -fmessage-length=0 -fvisibility=hidden -I/usr/local/include/libxml2 -I/usr/include -fpermissive -fvisibility-inlines-hidden -O2 -fno-strict-aliasing -pipe -Wall -fmessage-length=0 -fvisibility=hidden -I/usr/local/include/libxml2 -I/usr/include -fPIC -DQ_NO_STLPORT -I/usr/local/include/glib-2.0 -I/usr/local/lib/glib-2.0/include -I/usr/local/include -Ibuild/release/shobjs/include -Iinclude -Ibuild/release/shobjs/libs -Ilibs libs/splines/util_str.cpp
libs/splines/util_str.cpp: In function 'void TestStringClass()':
libs/splines/util_str.cpp:483:51: error: invalid cast from type 'std::nullptr_t' to type 'const char*'
  idStr e( reinterpret_cast<const char *>( NULL ) );
                                                   ^
libs/splines/util_str.cpp:502:50: error: invalid cast from type 'std::nullptr_t' to type 'const char*'
  a = c + reinterpret_cast<const char *>( NULL );
                                                  ^
libs/splines/util_str.cpp:505:46: error: invalid cast from type 'std::nullptr_t' to type 'const char*'
  a = reinterpret_cast<const char *>( NULL ) + d;
                                              ^
libs/splines/util_str.cpp:509:47: error: invalid cast from type 'std::nullptr_t' to type 'const char*'
  a += reinterpret_cast<const char *>( NULL );
                                               ^
scons: *** [build/release/shobjs/libs/splines/util_str.os] Error 1
scons: building terminated because of errors.
```

I [read there](http://en.cppreference.com/w/cpp/language/reinterpret_cast) about `reinterpret_cast` that:

> A value of any integral or enumeration type can be converted to a pointer type. A pointer converted to an integer of sufficient size and back to the same pointer type is guaranteed to have its original value, otherwise the resulting pointer cannot be dereferenced safely (the round-trip conversion in the opposite direction is not guaranteed; the same pointer may have multiple integer representations) **The null pointer constant `NULL` or integer zero is not guaranteed to yield the null pointer value of the target type; `static_cast` or implicit conversion should be used for this purpose**.

So I substituted all the `reinterpret_cast` on NULL on this file with `static_cast`, and it re-enabled the build. The modified code still builds on GCC 5 and GCC 6.

Edit: same fix discussed on NetRadiant side: [NetRadiant!74](https://gitlab.com/xonotic/netradiant/merge_requests/74).