### PR TITLE
Enable FreeBSD build, fix #378

### DIFF
--- a/SConscript.radiant
+++ b/SConscript.radiant
@@ -4,12 +4,16 @@
 # http://scons.org/
 
 import os
+import platform
 
 Import( [ 'utils', 'config', 'settings', 'lib_objects' ] )
 
 env = Environment( ENV = os.environ )
 settings.SetupEnvironment( env, config[ 'name' ], useGtk = True, useGtkGL = True )
-env.Append( LIBS = [ 'dl' ] )
+
+if ( platform.system() != 'FreeBSD' ):
+	env.Append( LIBS = [ 'dl' ] )
+
 proj = utils.vcxproj( os.path.join( GetLaunchDir(), 'radiant/radiant.vcxproj' ) )
 
 radiant = env.Program( 'radiant.bin', lib_objects + [ os.path.join( 'radiant', i ) for i in proj.getSourceFiles() ] )

--- a/config.py
+++ b/config.py
@@ -20,8 +20,12 @@ class Config:
         self.config_selected = [ 'release' ]
         # those are global to each config
         self.platform = platform.system()
-        self.cc = 'gcc'
-        self.cxx = 'g++'
+        if ( self.platform == 'FreeBSD' ):
+            self.cc = 'cc'
+            self.cxx = 'c++'
+        else:
+            self.cc = 'gcc'
+            self.cxx = 'g++'
         self.install_directory = 'install'
 
         # platforms for which to assemble a setup

--- a/contrib/bobtoolz/StdAfx.h
+++ b/contrib/bobtoolz/StdAfx.h
@@ -35,7 +35,7 @@
 
 #include "time.h"
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 
 // Necessary for proper boolean type declaration
 #include "qertypes.h"
@@ -116,7 +116,7 @@ typedef struct tagRECT
 
 typedef uint UINT;
 
-#endif // __linux__
+#endif // defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 
 #include "synapse.h"
 #include "iplugin.h"

--- a/contrib/bobtoolz/misc.cpp
+++ b/contrib/bobtoolz/misc.cpp
@@ -195,7 +195,7 @@ extern const char* PLUGIN_NAME;
     return buffer;
    }*/
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 // the bCreateConsole parameter is ignored on linux ..
 bool Q_Exec( const char *pCmd, bool bCreateConsole ){
 	switch ( fork() )

--- a/contrib/camera/funchandlers.cpp
+++ b/contrib/camera/funchandlers.cpp
@@ -29,7 +29,7 @@
 extern GtkWidget *g_pEditModeAddRadioButton;
 
 char* Q_realpath( const char *path, char *resolved_path, size_t size ){
-#if defined  ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	return realpath( path, resolved_path );
 #else
 	return _fullpath( resolved_path, path, size );

--- a/contrib/gtkgensurf/gensurf.h
+++ b/contrib/gtkgensurf/gensurf.h
@@ -35,7 +35,7 @@
 #define PLUGIN
 #define Q3RADIANT
 
-#if defined( __linux__ ) || defined( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 template <class T>
 inline T min( T x, T y ) { return ( x < y ) ? x : y; }
 template <class T>

--- a/contrib/prtview/prtview.cpp
+++ b/contrib/prtview/prtview.cpp
@@ -73,7 +73,7 @@ void InitInstance(){
 	strcat( INIfn, fn_dir );
 	strcat( INIfn, fn_name );
 	strcat( INIfn, ".ini" );
-#else // if def __linux__
+#else // if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	strcpy( INIfn, g_get_home_dir() );
 	strcat( INIfn, "/.radiant/" );
 	strcat( INIfn, RADIANT_VERSION );
@@ -166,7 +166,7 @@ _QERQglTable g_QglTable;
 
 #define CONFIG_SECTION "Configuration"
 
-#if defined( __linux__ ) || defined( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 
 static bool read_var( const char *filename, const char *section, const char *key, char *value ){
 	char line[1024], *ptr;
@@ -316,7 +316,7 @@ static bool save_var( const char *filename, const char *section, const char *key
 #endif
 
 int INIGetInt( const char *key, int def ){
-#if defined( __linux__ ) || defined( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	char value[1024];
 
 	if ( read_var( INIfn, CONFIG_SECTION, key, value ) ) {
@@ -339,7 +339,7 @@ void INISetInt( const char *key, int val, const char *comment /* = NULL */ ){
 	else{
 		sprintf( s, "%d", val );
 	}
-#if defined( __linux__ ) || defined( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	save_var( INIfn, CONFIG_SECTION, key, s );
 #else
 	WritePrivateProfileString( CONFIG_SECTION, key, s, INIfn );

--- a/contrib/prtview/stdafx.h
+++ b/contrib/prtview/stdafx.h
@@ -24,7 +24,7 @@
 #include <gtk/gtk.h>
 #include <stdint.h>
 
-#if defined( __linux__ ) || defined( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #include <GL/glx.h>
 
 // Necessary for proper boolean type declaration
@@ -46,7 +46,7 @@ typedef int BOOL;
 #define IDOK                1
 #define IDCANCEL            2
 
-#endif // __linux__
+#endif // defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 
 #include "synapse.h"
 

--- a/include/igl.h
+++ b/include/igl.h
@@ -29,7 +29,7 @@
 #ifndef __IGL_H__
 #define __IGL_H__
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #include <GL/glx.h>
 #endif
 

--- a/libs/cmdlib/cmdlib.cpp
+++ b/libs/cmdlib/cmdlib.cpp
@@ -28,7 +28,7 @@
 #ifdef _WIN32
   #include <windows.h>
 #endif
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
   #include <unistd.h>
 #endif
 
@@ -36,7 +36,7 @@
 // NOTE: we don't use this crap .. with the total mess of mixing win32/unix paths we need to recognize both '/' and '\\'
 #define PATHSEPERATOR   '/'
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 bool Q_Exec( const char *cmd, char *cmdline, const char *execdir, bool bCreateConsole ){
 	char fullcmd[2048];
 	char *pCmd;

--- a/libs/l_net/l_net.c
+++ b/libs/l_net/l_net.c
@@ -81,7 +81,7 @@ int Net_AddressCompare( address_t *addr1, address_t *addr2 ){
 #ifdef _WIN32
 	return stricmp( addr1->ip, addr2->ip );
 #endif
-#if __linux__ || __APPLE__
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	return strcasecmp( addr1->ip, addr2->ip );
 #endif
 } //end of the function Net_AddressCompare

--- a/libs/l_net/l_net.c
+++ b/libs/l_net/l_net.c
@@ -80,9 +80,10 @@ void Net_SetAddressPort( address_t *address, int port ){
 int Net_AddressCompare( address_t *addr1, address_t *addr2 ){
 #ifdef _WIN32
 	return stricmp( addr1->ip, addr2->ip );
-#endif
-#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
+#elif defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	return strcasecmp( addr1->ip, addr2->ip );
+#else
+	#error unknown architecture
 #endif
 } //end of the function Net_AddressCompare
 //===========================================================================

--- a/libs/pak/pakstuff.cpp
+++ b/libs/pak/pakstuff.cpp
@@ -23,7 +23,7 @@
 #include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #include <dirent.h>
 #endif
 #ifdef _WIN32
@@ -71,7 +71,7 @@ struct PK3FileInfo
 
 #ifdef LOG_PAKFAIL
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #include <unistd.h>
 #include <pwd.h>
 #endif
@@ -82,7 +82,7 @@ class LogFile
 public:
 FILE *m_pFile;
 LogFile( const char* pName ){
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	// leo: use ~/.q3a/radiant/paklog instead of /tmp/paklog.txt
 	char *home = NULL;
 
@@ -869,7 +869,7 @@ void WINAPI InitPakFile( const char * pBasePath, const char *pName ){
 
 	if ( pName == NULL ) {
 		//++timo FIXME: use some kind of compatibility lib here!
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 		char cWork[WORK_LEN];
 		struct dirent *dirlist;
 		DIR *dir;

--- a/libs/splines/q_shared.h
+++ b/libs/splines/q_shared.h
@@ -158,6 +158,8 @@ void osxFreeMemory( void *pointer );
 
 #ifdef __MACOS__
 
+// the mac compiler can't handle >32k of locals, so we
+// just waste space and make big arrays static...
 #define MAC_STATIC static
 
 #define CPUSTRING   "MacOS-PPC"
@@ -186,8 +188,6 @@ void Sys_PumpEvents( void );
 
 //======================= LINUX DEFINES =================================
 
-// the mac compiler can't handle >32k of locals, so we
-// just waste space and make big arrays static...
 #ifdef __linux__
 
 #define MAC_STATIC

--- a/libs/splines/q_shared.h
+++ b/libs/splines/q_shared.h
@@ -204,6 +204,22 @@ void Sys_PumpEvents( void );
 
 #endif
 
+//======================= FreeBSD DEFINES =================================
+
+#ifdef __FreeBSD__
+
+#define MAC_STATIC
+
+#ifdef __i386__
+#define CPUSTRING   "FreeBSD-i386"
+#else
+#define CPUSTRING   "FreeBSD-other"
+#endif
+
+#define PATH_SEP '/'
+
+#endif
+
 //=============================================================
 
 typedef enum {qfalse, qtrue}    qboolean;

--- a/libs/splines/q_shared.h
+++ b/libs/splines/q_shared.h
@@ -152,11 +152,9 @@ void osxFreeMemory( void *pointer );
 }
 #endif
 
-#endif
-
 //======================= MAC DEFINES =================================
 
-#ifdef __MACOS__
+#elif defined( __MACOS__ )
 
 // the mac compiler can't handle >32k of locals, so we
 // just waste space and make big arrays static...
@@ -184,11 +182,10 @@ void Sys_PumpEvents( void );
 #define QDECL   __cdecl
 
 #define _alloca alloca
-#endif
 
 //======================= LINUX DEFINES =================================
 
-#ifdef __linux__
+#elif defined( __linux__ )
 
 #define MAC_STATIC
 
@@ -202,11 +199,9 @@ void Sys_PumpEvents( void );
 
 #define PATH_SEP '/'
 
-#endif
-
 //======================= FreeBSD DEFINES =================================
 
-#ifdef __FreeBSD__
+#elif defined( __FreeBSD__ )
 
 #define MAC_STATIC
 
@@ -218,9 +213,11 @@ void Sys_PumpEvents( void );
 
 #define PATH_SEP '/'
 
-#endif
-
 //=============================================================
+
+#else
+	#error unknown architecture
+#endif
 
 typedef enum {qfalse, qtrue}    qboolean;
 

--- a/libs/str.h
+++ b/libs/str.h
@@ -75,7 +75,7 @@ inline char* Q_StrDup( const char* pStr ) {
 	return strcpy( new char[strlen( pStr ) + 1], pStr );
 }
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #define strcmpi strcasecmp
 #define stricmp strcasecmp
 #define strnicmp strncasecmp

--- a/libs/synapse.h
+++ b/libs/synapse.h
@@ -48,7 +48,7 @@
   #include <sys/types.h>
 #endif
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
   #include <dlfcn.h>
   #include <dirent.h>
 #endif
@@ -59,7 +59,7 @@
 
 #if defined( _WIN32 )
   #define SYNAPSE_DLL_EXPORT WINAPI
-#elif defined( __linux__ ) || defined( __APPLE__ )  /* ydnar */
+#elif defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )  /* ydnar */
   #define SYNAPSE_DLL_EXPORT
 #else
   #error unknown architecture
@@ -459,7 +459,7 @@ public:
 /*!
    \todo cleanup, make that private with accessors
  */
-#if defined( __linux__ ) || defined( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 void *mpDLL;   ///< handle to the shared object (invalid if SYN_BUILTIN)
 #elif defined( _WIN32 )
 HMODULE mpDLL;   ///< handle to the shared object (invalid if SYN_BUILTIN)

--- a/libs/synapse/synapse.cpp
+++ b/libs/synapse/synapse.cpp
@@ -26,7 +26,7 @@
 #include <glib/gstdio.h>
 
 #include "synapse.h"
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
   #include <dirent.h>
 #endif
 
@@ -145,7 +145,7 @@ bool CSynapseServer::Initialize( const char* conf_file, PFN_SYN_PRINTF_VA pf ){
 				// too small to be isolated in win32/ and linux/ directories..
 #if defined( _WIN32 )
 				const char* ext_so = ".dll";
-#elif defined ( __linux__ ) || defined ( __APPLE__ )
+#elif defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 				const char* ext_so = ".so";
 #endif
 				const char* ext = strrchr( name, '.' );
@@ -221,7 +221,7 @@ void CSynapseClientSlot::ReleaseSO(){
 	mpDLL = NULL;
 }
 
-#elif defined( __linux__ ) || defined ( __APPLE__ )
+#elif defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 void CSynapseServer::EnumerateInterfaces( Str &soname ){
 	CSynapseClientSlot slot;
 	slot.mpDLL = dlopen( soname.GetBuffer(), RTLD_NOW );

--- a/plugins/textool/StdAfx.h
+++ b/plugins/textool/StdAfx.h
@@ -29,7 +29,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#if defined( __linux__ ) || defined( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 
 // Necessary for proper boolean type declaration
 #include "qertypes.h"
@@ -79,7 +79,7 @@ typedef struct tagRECT
 	long bottom;
 } RECT, *PRECT, *LPRECT;
 
-#endif // __linux__
+#endif // defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 
 // plugin
 // FIXME TTimo: drop this

--- a/plugins/vfspak/vfs.cpp
+++ b/plugins/vfspak/vfs.cpp
@@ -43,7 +43,7 @@
 
 #include <glib.h>
 #include <stdio.h>
-#if defined __linux__ || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	#include <dirent.h>
 	#include <unistd.h>
 	#define WINAPI

--- a/plugins/vfspk3/vfs.cpp
+++ b/plugins/vfspk3/vfs.cpp
@@ -45,7 +45,7 @@
 #include <stdio.h>
 #include <errno.h>
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
   #include <dirent.h>
   #include <unistd.h>
 #else

--- a/plugins/vfsqlpk3/vfs.cpp
+++ b/plugins/vfsqlpk3/vfs.cpp
@@ -44,7 +44,7 @@
 #include <glib.h>
 #include <stdio.h>
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
   #include <dirent.h>
   #include <unistd.h>
 #else

--- a/plugins/vfswad/vfs.cpp
+++ b/plugins/vfswad/vfs.cpp
@@ -44,7 +44,7 @@
 #include <glib.h>
 #include <stdio.h>
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
   #include <dirent.h>
   #include <unistd.h>
 #else
@@ -119,7 +119,7 @@ int vfsBuildShortPathName( const char* pPath, char* pBuffer, int nBufferLen ){
 		strcpy( pBuffer, pPath );               // Use long filename
 	}
 	return nResult;
-#elif defined ( __linux__ ) || defined ( __APPLE__ )
+#elif defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 
 	// remove /../ from directories
 	const char *scr = pPath; char *dst = pBuffer;

--- a/radiant/eclass.cpp
+++ b/radiant/eclass.cpp
@@ -21,7 +21,7 @@
 
 #include "stdafx.h"
 #include <sys/stat.h>
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #include <dirent.h>
 #endif
 #include "assert.h"

--- a/radiant/error.cpp
+++ b/radiant/error.cpp
@@ -22,7 +22,7 @@
 #define UNICODE
 #include "stdafx.h"
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #include <unistd.h>
 #endif
 
@@ -52,7 +52,7 @@ void Error( const char *error, ... ){
 
 	strcat( text, "\n" );
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	if ( errno != 0 ) {
 		strcat( text, "errno: " );
 		strcat( text, strerror( errno ) );

--- a/radiant/gtkmisc.cpp
+++ b/radiant/gtkmisc.cpp
@@ -35,7 +35,7 @@
 #include <gdk/gdkkeysyms.h>
 #include <glib/gi18n.h>
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #include <unistd.h>
 #endif
 

--- a/radiant/main.cpp
+++ b/radiant/main.cpp
@@ -477,6 +477,8 @@ int mainRadiant( int argc, char* argv[] ) {
 			libgl = "libGL.so.1";
 		#elif defined ( __APPLE__ )
 			libgl = "/opt/local/lib/libGL.dylib";
+		#else
+			#error unknown architecture
 		#endif
 	}
 

--- a/radiant/main.cpp
+++ b/radiant/main.cpp
@@ -19,7 +19,7 @@
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
   #include <gdk/gdkx.h>
   #include <pwd.h>
   #include <unistd.h>
@@ -118,7 +118,7 @@ static void create_splash() {
 // =============================================================================
 // Loki stuff
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 
 /* A short game name, could be used as argv[0] */
 static char game_name[100] = "";
@@ -480,7 +480,7 @@ int mainRadiant( int argc, char* argv[] ) {
 		#endif
 	}
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	// Give away unnecessary root privileges.
 	// Important: must be done before calling gtk_init().
 	char *loginname;
@@ -578,7 +578,7 @@ int mainRadiant( int argc, char* argv[] ) {
 
 #endif
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	Str home;
 	home = g_get_home_dir();
 	AddSlash( home );
@@ -860,7 +860,7 @@ int mainRadiant( int argc, char* argv[] ) {
 		return 1;
 	}
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	if ( ( qglXQueryExtension == NULL ) || ( qglXQueryExtension( gdk_x11_get_default_xdisplay(), NULL, NULL ) != True ) ) {
 		Sys_FPrintf( SYS_ERR, "glXQueryExtension failed\n" );
 		_exit( 1 );
@@ -1128,7 +1128,7 @@ void SaveWithRegion( char *name ){
 	Map_SaveFile( name, region_active );
 }
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 typedef struct {
 	pid_t pid;
 	int status;
@@ -1240,7 +1240,7 @@ void RunBsp( char *command ){
 			strSys += "\n";
 		};
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 
 		// write qe3bsp.sh
 		sprintf( batpath, "%sqe3bsp.sh", temppath );
@@ -1269,7 +1269,7 @@ void RunBsp( char *command ){
 
 		Pointfile_Delete();
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 		bsp_child_process_t *process = ( bsp_child_process_t *) malloc( sizeof( bsp_child_process_t ) );
 		memset( process, 0, sizeof( *process ) );
 

--- a/radiant/main.cpp
+++ b/radiant/main.cpp
@@ -473,7 +473,7 @@ int mainRadiant( int argc, char* argv[] ) {
 	if ( libgl == NULL ) {
 		#if defined ( _WIN32 )
 			libgl = "opengl32.dll";
-		#elif defined ( __linux__ )
+		#elif defined ( __linux__ ) || defined ( __FreeBSD__ )
 			libgl = "libGL.so.1";
 		#elif defined ( __APPLE__ )
 			libgl = "/opt/local/lib/libGL.dylib";

--- a/radiant/mainframe.cpp
+++ b/radiant/mainframe.cpp
@@ -31,7 +31,7 @@
 #include <gdk/gdkkeysyms.h>
 #include <gdk/gdkprivate.h>
 #include <sys/stat.h>
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
   #include <unistd.h>
 #endif
 #include "gtkmisc.h"
@@ -2161,7 +2161,7 @@ void Clipboard_PasteMap(){
    Platform-independent GTK clipboard support.
    \todo Using GDK_SELECTION_CLIPBOARD fails on win32, so we use the win32 API directly for now.
  */
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 
 enum
 {
@@ -3586,7 +3586,7 @@ void MainFrame::LoadCommandMap(){
 	int j;
 
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	strINI = g_PrefsDlg.m_rc_path->str;
 #elif defined( WIN32 )
 	strINI = g_strGameToolsPath;

--- a/radiant/map.cpp
+++ b/radiant/map.cpp
@@ -22,7 +22,7 @@
 #include "stdafx.h"
 #include <glib/gi18n.h>
 #include <string.h>
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #include <unistd.h>
 #endif
 #include "preferences.h"

--- a/radiant/missing.cpp
+++ b/radiant/missing.cpp
@@ -38,7 +38,7 @@
 #include "qsysprintf.h"
 #include "qe3.h"
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 
 #include <stdio.h>
 #include <unistd.h>

--- a/radiant/pluginentities.cpp
+++ b/radiant/pluginentities.cpp
@@ -28,7 +28,7 @@
 #ifdef USEPLUGINENTITIES
 
 #include "stdafx.h"
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #include <dirent.h>
 #endif
 //#include "qe3.h"

--- a/radiant/pluginmanager.cpp
+++ b/radiant/pluginmanager.cpp
@@ -24,7 +24,7 @@
 //////////////////////////////////////////////////////////////////////
 
 #include "stdafx.h"
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
   #include <dirent.h>
   #include <sys/time.h>
 #endif
@@ -1898,7 +1898,7 @@ void CPlugInManager::CommitPatchHandleToEntity( int index, patchMesh_t *pMesh, c
 
 #if 0
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
   #include <gdk/gdkx.h>
 
 XVisualInfo* QEX_ChooseVisual( bool zbuffer ){

--- a/radiant/preferences.cpp
+++ b/radiant/preferences.cpp
@@ -29,7 +29,7 @@
 #include <glib.h>
 #include <glib/gi18n.h>
 #include <assert.h>
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <fcntl.h>
@@ -1321,7 +1321,7 @@ void CGameDialog::Init(){
 
 	// Add the per-user game path on all platforms
 	if ( m_pCurrentGameDescription->mUserPathPrefix.GetLength() ) {
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 		g_qeglobals.m_strHomeGame = g_get_home_dir();
 		g_qeglobals.m_strHomeGame += "/";
 		g_qeglobals.m_strHomeGame += m_pCurrentGameDescription->mUserPathPrefix.GetBuffer();
@@ -3722,7 +3722,7 @@ void CGameInstall::Run() {
 		break;
 	}
 	case GAME_QUETOO: {
-#if defined( __APPLE__ ) || defined( __linux__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 		fprintf( fg, "  " ENGINE_ATTRIBUTE "=\"quetoo\"\n" );
 		fprintf( fg, "  " PREFIX_ATTRIBUTE "=\".quetoo\"\n" );
 #elif _WIN32

--- a/radiant/preferences.cpp
+++ b/radiant/preferences.cpp
@@ -794,7 +794,7 @@ CGameDescription::CGameDescription( xmlDocPtr pDoc, const Str &GameFile ){
 	if ( prop == NULL ) {
 #ifdef _WIN32
 		mEngine = "quake3.exe";
-#elif __linux__
+#elif defined( __linux__ ) || defined( __FreeBSD__ )
 		mEngine = "quake3";
 #elif __APPLE__
 		mEngine = "Quake3.app";
@@ -808,7 +808,7 @@ CGameDescription::CGameDescription( xmlDocPtr pDoc, const Str &GameFile ){
 	if ( prop == NULL ) {
 #ifdef _WIN32
 		mMultiplayerEngine = "quake3.exe";
-#elif __linux__
+#elif defined( __linux__ ) || defined( __FreeBSD__ )
 		mMultiplayerEngine = "quake3";
 #elif __APPLE__
 		mMultiplayerEngine = "Quake3.app";
@@ -3775,7 +3775,7 @@ void CGameInstall::Run() {
 	case GAME_ET: {
 #ifdef _WIN32
 		fprintf( fg, "  " ENGINE_ATTRIBUTE "=\"ET.exe\"\n");
-#elif __linux__
+#elif defined( __linux__ ) || defined( __FreeBSD__ )
 		fprintf( fg, "  " ENGINE_ATTRIBUTE "=\"et\"\n" );
 #endif
 		fprintf( fg, "  prefix=\".etwolf\"\n" );

--- a/radiant/qe3.cpp
+++ b/radiant/qe3.cpp
@@ -30,7 +30,7 @@
 #include <sys/stat.h>
 #include "gtkmisc.h"
 #include <glib/gi18n.h>
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #include <unistd.h>
 #include <X11/keysym.h>
 #include <gdk/gdkx.h>
@@ -171,7 +171,7 @@ void Map_Snapshot(){
 		bGo = ( _mkdir( strOrgPath ) != -1 );
 #endif
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 		bGo = ( mkdir( strOrgPath,0755 ) != -1 );
 #endif
 	}
@@ -288,7 +288,7 @@ int BuildShortPathName( const char* pPath, char* pBuffer, int nBufferLen ){
 }
 #endif
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 int BuildShortPathName( const char* pPath, char* pBuffer, int nBufferLen ){
 	// remove /../ from directories
 	const char *scr = pPath; char *dst = pBuffer;
@@ -1208,7 +1208,7 @@ bool Sys_AltDown(){
 	return ( GetKeyState( VK_MENU ) & 0x8000 ) != 0;
 #endif
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	char keys[32];
 	int x;
 
@@ -1244,7 +1244,7 @@ bool Sys_ShiftDown(){
 	return ( GetKeyState( VK_SHIFT ) & 0x8000 ) != 0;
 #endif
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	char keys[32];
 	int x;
 
@@ -1329,7 +1329,7 @@ void Sys_SetCursorPos( int x, int y ){
 }
 
 void Sys_Beep( void ){
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	gdk_beep();
 #else
 	MessageBeep( MB_ICONASTERISK );
@@ -1702,7 +1702,7 @@ void Sys_LogFile( void ){
 		Str name;
 		name = g_strTempPath;
 		name += "radiant.log";
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 		g_qeglobals.hLogFile = open( name.GetBuffer(), O_TRUNC | O_CREAT | O_WRONLY, S_IREAD | S_IWRITE );
 #endif
 #ifdef _WIN32
@@ -1729,7 +1729,7 @@ void Sys_LogFile( void ){
 		#ifdef _WIN32
 		_close( g_qeglobals.hLogFile );
 		#endif
-		#if defined ( __linux__ ) || defined ( __APPLE__ )
+		#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 		close( g_qeglobals.hLogFile );
 		#endif
 		g_qeglobals.hLogFile = 0;
@@ -1757,7 +1757,7 @@ extern "C" void Sys_FPrintf_VA( int level, const char *text, va_list args ) {
 		_write( g_qeglobals.hLogFile, buf, length );
 		_commit( g_qeglobals.hLogFile );
 #endif
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 		write( g_qeglobals.hLogFile, buf, length );
 #endif
 	}

--- a/radiant/qgl.c
+++ b/radiant/qgl.c
@@ -37,7 +37,7 @@
 #include <stdio.h>
 #include <float.h>
 #include <string.h>
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #include <dlfcn.h>
 #endif
 
@@ -88,7 +88,7 @@ BOOL ( WINAPI * qwglSwapIntervalEXT )( int interval );
 #define WINAPI
 #endif
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 void* g_hGLDLL;
 
 XVisualInfo* ( *qglXChooseVisual )( Display * dpy, int screen, int *attribList );
@@ -525,7 +525,7 @@ void QGL_Shutdown(){
 		FreeLibrary( g_hGLDLL );
 #endif
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 		dlclose( g_hGLDLL );
 #endif
 
@@ -936,7 +936,7 @@ void QGL_Shutdown(){
 	qwglSetDeviceGammaRampEXT    = NULL;
 #endif
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	qglXChooseVisual             = NULL;
 	qglXCreateContext            = NULL;
 	qglXDestroyContext           = NULL;
@@ -986,7 +986,7 @@ static void* safe_dlsym( void *handle, char *symbol ){
 	return GetProcAddress( handle, symbol );
 #endif
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	void* ret = dlsym( handle, symbol );
 	const char *err = dlerror();
 	if ( err ) {
@@ -1174,7 +1174,7 @@ int QGL_Init( const char *dllname, const char* gluname ){
 	g_hGLDLL = LoadLibrary( dllname );
 #endif
 
-#if defined ( __linux__ ) || ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	const char *err;
 
 	// NOTE TTimo
@@ -1623,7 +1623,7 @@ int QGL_Init( const char *dllname, const char* gluname ){
 	qglMTexCoord2fSGIS = 0;
 #endif
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	qglXChooseVisual             = safe_dlsym( g_hGLDLL, "glXChooseVisual" );
 	qglXCreateContext            = safe_dlsym( g_hGLDLL, "glXCreateContext" );
 	qglXDestroyContext           = safe_dlsym( g_hGLDLL, "glXDestroyContext" );
@@ -1704,7 +1704,7 @@ int GL_ExtensionSupported( const char *extension ){
 }
 
 void* Sys_GLGetExtension( const char *symbol ){
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	if ( qglXGetProcAddressARB == NULL ) {
 		return NULL;
 	}

--- a/radiant/qgl.h
+++ b/radiant/qgl.h
@@ -30,7 +30,7 @@
 
 #include <GL/gl.h>
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #include <GL/glx.h>
 #endif
 
@@ -521,7 +521,7 @@ extern BOOL ( WINAPI * qwglSetDeviceGammaRampEXT )( const unsigned char *pRed, c
 
 #endif
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 extern XVisualInfo* ( *qglXChooseVisual )( Display * dpy, int screen, int *attribList );
 extern GLXContext ( *qglXCreateContext )( Display *dpy, XVisualInfo *vis, GLXContext shareList, Bool direct );
 extern void ( *qglXDestroyContext )( Display *dpy, GLXContext ctx );

--- a/radiant/texwindow.cpp
+++ b/radiant/texwindow.cpp
@@ -32,7 +32,7 @@
    - Make sure the interface is not dependent on gtk.
  */
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #include <dirent.h>
 #endif
 #include <gtk/gtk.h>

--- a/radiant/watchbsp.cpp
+++ b/radiant/watchbsp.cpp
@@ -41,7 +41,7 @@
 #include <winsock2.h>
 #endif
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #include <sys/time.h>
 #define SOCKET_ERROR -1
 #endif
@@ -421,7 +421,7 @@ void CWatchBSP::RoutineProcessing(){
 #ifdef _WIN32
 	TIMEVAL tout = { 0, 0 };
 #endif
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	timeval tout;
 	tout.tv_sec = 0;
 	tout.tv_usec = 0;

--- a/tools/quake2/common/cmdlib.c
+++ b/tools/quake2/common/cmdlib.c
@@ -32,7 +32,7 @@
 #include <windows.h>
 #endif
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #include <unistd.h>
 #endif
 
@@ -1180,7 +1180,7 @@ void Sys_Sleep( int n ){
 #ifdef WIN32
 	Sleep( n );
 #endif
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	usleep( n * 1000 );
 #endif
 }

--- a/tools/quake2/common/path_init.c
+++ b/tools/quake2/common/path_init.c
@@ -28,7 +28,7 @@
 /* marker */
 #define PATH_INIT_C
 
-#if defined( __linux__ ) || defined( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	#define Q_UNIX
 #endif
 

--- a/tools/quake2/common/threads.c
+++ b/tools/quake2/common/threads.c
@@ -415,7 +415,7 @@ void RunThreadsOn( int workcnt, qboolean showpacifier, void ( *func )( int ) ){
    =======================================================================
  */
 
-#if defined( __linux__ ) || defined( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #define USED
 
 // Setting default Threads to 1

--- a/tools/quake2/common/threads.c
+++ b/tools/quake2/common/threads.c
@@ -571,7 +571,7 @@ void RunThreadsOn( int workcnt, qboolean showpacifier, void ( *func )( int ) ){
 		Sys_Printf( " (%i)\n", end - start );
 	}
 }
-#endif // ifdef __linux__
+#endif // if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 
 
 /*

--- a/tools/quake2/q2map/q2map.h
+++ b/tools/quake2/q2map/q2map.h
@@ -21,7 +21,7 @@
 // q2map.h
 
 /* platform-specific */
-#if defined( __linux__ ) || defined( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	#define Q_UNIX
 #endif
 

--- a/tools/quake2/qdata_heretic2/common/cmdlib.c
+++ b/tools/quake2/qdata_heretic2/common/cmdlib.c
@@ -32,7 +32,7 @@
 #include <windows.h>
 #endif
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #include <unistd.h>
 #endif
 
@@ -84,7 +84,7 @@ void *SafeMalloc( size_t n, char *desc ){
 	return p;
 }
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 void strlwr( char *conv_str ){
 	int i;
 
@@ -1192,7 +1192,7 @@ void Sys_Sleep( int n ){
 #ifdef WIN32
 	Sleep( n );
 #endif
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	usleep( n * 1000 );
 #endif
 }

--- a/tools/quake2/qdata_heretic2/common/path_init.c
+++ b/tools/quake2/qdata_heretic2/common/path_init.c
@@ -29,7 +29,7 @@
 /* marker */
 #define PATH_INIT_C
 
-#if defined( __linux__ ) || defined( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	#define Q_UNIX
 #endif
 

--- a/tools/quake2/qdata_heretic2/common/threads.c
+++ b/tools/quake2/qdata_heretic2/common/threads.c
@@ -414,7 +414,7 @@ void RunThreadsOn( int workcnt, qboolean showpacifier, void ( *func )( int ) ){
    =======================================================================
  */
 
-#ifdef __linux__
+#if defined( __linux__ ) || defined( __FreeBSD__ )
 #define USED
 
 int numthreads = 4;
@@ -569,7 +569,7 @@ void RunThreadsOn( int workcnt, qboolean showpacifier, void ( *func )( int ) ){
 		Sys_Printf( " (%i)\n", end - start );
 	}
 }
-#endif // ifdef __linux__
+#endif // if defined( __linux__ ) || defined( __FreeBSD__ )
 
 
 /*

--- a/tools/quake3/common/aselib.c
+++ b/tools/quake3/common/aselib.c
@@ -114,7 +114,7 @@ static char gl_filename[1024];
 static void ASE_Process( void );
 static void ASE_FreeGeomObject( int ndx );
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 
 static char* strlwr( char* string ){
 	char *cp;

--- a/tools/quake3/common/cmdlib.c
+++ b/tools/quake3/common/cmdlib.c
@@ -39,7 +39,7 @@
 #include <windows.h>
 #endif
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #include <unistd.h>
 #endif
 
@@ -1081,7 +1081,7 @@ void Sys_Sleep( int n ){
 #ifdef WIN32
 	Sleep( n );
 #endif
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	usleep( n * 1000 );
 #endif
 }

--- a/tools/quake3/common/threads.c
+++ b/tools/quake3/common/threads.c
@@ -414,7 +414,7 @@ void RunThreadsOn( int workcnt, qboolean showpacifier, void ( *func )( int ) ){
    =======================================================================
  */
 
-#ifdef __linux__
+#if defined( __linux__ ) || defined( __FreeBSD__ )
 #define USED
 
 int numthreads = 4;
@@ -570,7 +570,7 @@ void RunThreadsOn( int workcnt, qboolean showpacifier, void ( *func )( int ) ){
 		Sys_Printf( " (%i)\n", end - start );
 	}
 }
-#endif // ifdef __linux__
+#endif // if defined( __linux__ ) || defined( __FreeBSD__ )
 
 
 /*

--- a/tools/quake3/common/trilib.c
+++ b/tools/quake3/common/trilib.c
@@ -38,7 +38,7 @@
 
 //#define NOISY 1
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #define strlwr strlower
 #endif
 

--- a/tools/quake3/common/vfs.c
+++ b/tools/quake3/common/vfs.c
@@ -43,7 +43,7 @@
 
 #include <stdio.h>
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #include <dirent.h>
 #include <unistd.h>
 #else

--- a/tools/quake3/q3data/md3lib.c
+++ b/tools/quake3/q3data/md3lib.c
@@ -25,7 +25,7 @@
 #endif
 #include "md3lib.h"
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #define filelength Q_filelength
 #endif
 

--- a/tools/quake3/q3data/p3dlib.c
+++ b/tools/quake3/q3data/p3dlib.c
@@ -31,7 +31,7 @@
 
 #define MAX_POLYSETS 64
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #define _strcmpi Q_stricmp
 #define filelength Q_filelength
 #define strlwr strlower

--- a/tools/quake3/q3data/q3data.c
+++ b/tools/quake3/q3data/q3data.c
@@ -40,7 +40,7 @@ char *moddir = NULL;
 // some old defined that was in cmdlib lost during merge
 char writedir[1024];
 
-#if defined ( __linux__ ) || defined ( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 #define strlwr strlower
 #endif
 

--- a/tools/quake3/q3map2/q3map2.h
+++ b/tools/quake3/q3map2/q3map2.h
@@ -57,7 +57,7 @@ extern int unz_GAME_QL;
    ------------------------------------------------------------------------------- */
 
 /* platform-specific */
-#if defined( __linux__ ) || defined( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	#define Q_UNIX
 #endif
 

--- a/tools/urt/tools/quake3/q3map2/q3map2.h
+++ b/tools/urt/tools/quake3/q3map2/q3map2.h
@@ -47,7 +47,7 @@
    ------------------------------------------------------------------------------- */
 
 /* platform-specific */
-#if defined( __linux__ ) || defined( __APPLE__ )
+#if defined( __linux__ ) || defined( __FreeBSD__ ) || defined( __APPLE__ )
 	#define Q_UNIX
 #endif
 

--- a/utils.py
+++ b/utils.py
@@ -50,6 +50,9 @@ def CheckUnresolved( source, target, env ):
 	# TODO: implement this for OSX
 	if ( platform.system() == 'Darwin' ):
 		return None
+        # TODO: implement this for FreeBSD
+        if ( platform.system() == 'FreeBSD' ):
+                return None
 	print 'CheckUnresolved %s' % target[0].abspath
 	if ( not os.path.isfile( target[0].abspath ) ):
 		print 'CheckUnresolved: %s does not exist' % target[0]


### PR DESCRIPTION
Tested on FreeBSD 11.1 and GCC 5 (default) and GCC 6 (and with GCC 8 with fix from #564).
Compilation went well for all the binaries provided by the repository.

q3map2 runs but I was not able to test radiant: I get an early segfault but it means nothing at this point: even the default provided `gdb` mismatches with the installed `libstdc++` ¯\\\_(ツ)\_/¯, so I'm even not able to debug: the distro seems borked.

Edit: it works once scons uses the system compiler (based on clang) instead of gcc.

It fixes #378.