### PR TITLE
Use flexible array members

### DIFF
--- a/tools/quake3/common/polylib.c
+++ b/tools/quake3/common/polylib.c
@@ -68,7 +68,7 @@ winding_t   *AllocWinding( int points ){
 			c_peak_windings = c_active_windings;
 		}
 	}
-	s = sizeof( vec_t ) * 3 * points + sizeof( int );
+	s = sizeof( *w ) + points * sizeof( *w->p );
 	w = safe_malloc( s );
 	memset( w, 0, s );
 	return w;
@@ -96,7 +96,7 @@ winding_accu_t *AllocWindingAccu( int points ){
 			c_peak_windings = c_active_windings;
 		}
 	}
-	s = sizeof(*w) + (points > 4 ? sizeof(vec3_accu_t) * (points - 4) : 0);
+	s = sizeof( *w ) + points * sizeof( *w->p );
 	w = safe_malloc( s );
 	memset( w, 0, s );
 	return w;

--- a/tools/quake3/common/polylib.h
+++ b/tools/quake3/common/polylib.h
@@ -23,7 +23,7 @@
 typedef struct
 {
 	int numpoints;
-	vec3_t p[4];        // variable sized
+	vec3_t p[];
 } winding_t;
 
 #define MAX_POINTS_ON_WINDING   64
@@ -65,7 +65,7 @@ void pw( winding_t *w );
 typedef struct
 {
 	int numpoints;
-	vec3_accu_t p[4]; // variable sized
+	vec3_accu_t p[];
 } winding_accu_t;
 
 winding_accu_t  *BaseWindingForPlaneAccu( vec3_t normal, vec_t dist );

--- a/tools/quake3/q3map2/brush.c
+++ b/tools/quake3/q3map2/brush.c
@@ -93,7 +93,7 @@ brush_t *AllocBrush( int numSides ){
 	brush_t     *bb;
 	size_t c;
 
-	c = sizeof(*bb) + (numSides > 6 ? sizeof(side_t)*(numSides - 6) : 0);
+	c = sizeof( *bb ) + sizeof( *bb->sides ) * numSides;
 	bb = safe_malloc( c );
 	memset( bb, 0, c );
 	if ( numthreads == 1 ) {
@@ -1023,7 +1023,7 @@ void SplitBrush( brush_t *brush, int planenum, brush_t **front, brush_t **back )
 	for ( i = 0 ; i < 2 ; i++ )
 	{
 		b[i] = AllocBrush( brush->numsides + 1 );
-		memcpy( b[i], brush, sizeof( brush_t ) - sizeof( brush->sides ) );
+		memcpy( b[i], brush, sizeof( brush_t ) );
 		b[i]->numsides = 0;
 		b[i]->next = NULL;
 		b[i]->original = brush->original;

--- a/tools/quake3/q3map2/q3map2.h
+++ b/tools/quake3/q3map2/q3map2.h
@@ -893,7 +893,7 @@ typedef struct brush_s
 	vec3_t mins, maxs;
 	int numsides;
 
-	side_t sides[ 6 ];                      /* variably sized */
+	side_t sides[];                         /* variably sized */
 }
 brush_t;
 


### PR DESCRIPTION
Change winding_t, winding_accu_t and brush_t to use flexible array members rather than fixed-sized arrays.

The arrays were always meant to be variably sized, and objects are only ever allocated dynamically. Object size computations are simplified with this change.

Flexible arrays were introduced in C99, so this change means that we will require a C99-conforming compiler henceforth.

I leave it up to you to decide whether that's acceptable, and whether the build system needs changing. I think GCC changed its defaults to C11 and C++14 in version 6, but for other compilers we should probably add an explicit -std=c99 flag.

Following this change, we may like to replace `offsetof` by `sizeof` where appropriate, since `sizeof` is well-defined for flexible arrays to achieve exactly what we have been doing with `offsetof` so far. But I haven't tested that particular change yet, so that'll come separately.

(See also https://github.com/TTimo/bspc/pull/11.)