### PR TITLE
scons: do not look for vfsqlpk3, make diff easier

### DIFF
--- a/config.py
+++ b/config.py
@@ -31,7 +31,19 @@ class Config:
         # platforms for which to assemble a setup
         self.setup_platforms = [ 'local', 'x86', 'x64', 'win32' ]
         # paks to assemble in the setup
-        self.setup_packs = [ 'Q3Pack', 'UrTPack', 'ETPack', 'QLPack', 'Q2Pack', 'QuetooPack', 'JAPack', 'STVEFPack', 'WolfPack', 'UnvanquishedPack', 'Q1Pack' ]
+        self.setup_packs = [
+                        'Q3Pack',
+                        'UrTPack',
+                        'ETPack',
+                        'QLPack',
+                        'Q2Pack',
+                        'QuetooPack',
+                        'JAPack',
+                        'STVEFPack',
+                        'WolfPack',
+                        'UnvanquishedPack',
+                        'Q1Pack',
+        ]
 
     def __repr__( self ):
         return 'config: target=%s config=%s' % ( self.target_selected, self.config_selected )
@@ -94,7 +106,7 @@ class Config:
                 VariantDir( build_dir, '.', duplicate = 0 )
                 shlib_objects_extra[libname] = SConscript( os.path.join( build_dir, 'SConscript.lib' ) )
 
-            for project in [ 'plugins/vfsqlpk3/vfsqlpk3.vcxproj',
+            for project in [
                      'plugins/vfspk3/vfspk3.vcxproj',
                      'plugins/vfspak/vfspak.vcxproj',
                      'plugins/vfswad/vfswad.vcxproj',
@@ -118,7 +130,7 @@ class Config:
                      'contrib/hydratoolz/hydratoolz.vcxproj',
                      'contrib/bobtoolz/bobtoolz.vcxproj',
                      'contrib/gtkgensurf/gtkgensurf.vcxproj',
-                     'contrib/bkgrnd2d/bkgrnd2d.vcxproj'
+                     'contrib/bkgrnd2d/bkgrnd2d.vcxproj',
                  ]:
                 ( libpath, libname ) = os.path.split( project )
                 libname = os.path.splitext( libname )[0]


### PR DESCRIPTION
- vfsqlpk3 was removed, so scons does not have to build it and don't
  fail anymore.
- when I was maintaining offline unvanquished branch I got so much pain
  each time I rebased on master because of stupid merge conflict since
  git knows well how to merge line addition/deletion but not to merge
  addition/deletion within the same line… setting each gamepack names
  on its own line will save hours of manual stupid merge solve to people
  wanting to add games in the future.
- I also added a comma on another list because python allows to put comma
  on last element and that's great to reduce diff noise (adding another
  line after the last one does not require to modify the one that was
  the last one before).