### PR TITLE
don't download gamepacks on “scons -c” fix #477

### DIFF
--- a/config.py
+++ b/config.py
@@ -298,7 +298,8 @@ class Config:
             pass
         else:
             # special case, fetch external paks under the local install directory
-            self.FetchGamePaks( self.install_directory )
+            if not Environment().GetOption('clean'):
+                self.FetchGamePaks( self.install_directory )
         # NOTE: unrelated to self.setup_platforms - grab support files and binaries and install them
         if ( self.platform == 'Windows' ):
             backup_cwd = os.getcwd()


### PR DESCRIPTION
implements @Pan7's suggest from #477 

don't download gamepacks while cleaning the source tree (it does not clean game packs though but I'm not sure if it's needed or not).