### PR TITLE
unvanquished "src" mod for unvanquished mapping from source

### DIFF
--- a/radiant/gtkdlgs.cpp
+++ b/radiant/gtkdlgs.cpp
@@ -382,6 +382,9 @@ game_t gameList[] = {
 	{ "q2.game", "Quake II Mission Pack: Ground Zero", "rogue", qfalse, qfalse },
 	{ "q2.game", "Custom Quake II modification", "", qfalse, qtrue },
 
+	{ "unvanquished.game", "Unvanquished", "pkg", qtrue, qfalse },
+	{ "unvanquished.game", "Unvanquished from source", "src", qfalse, qfalse },
+
 };
 
 GList *newMappingModesListForGameFile( Str & mGameFile ){


### PR DESCRIPTION
This is just a small change to add an `src` mod to unvanquished. The [UnvanquishedAssets](https://github.com/UnvanquishedAssets/UnvanquishedAssets) repository stores sources in `src` and build them in `pkg` (the basegame) so people who wants to build stuff against official repository instead of delivered packages just have to use this repository as _engine path_ and set `src` as _mod_.