### PR TITLE
[q3map2] Avoid division by zero (remove removable singularity)

### DIFF
--- a/tools/quake3/q3map2/map.c
+++ b/tools/quake3/q3map2/map.c
@@ -1052,8 +1052,12 @@ static void ParseRawBrush( qboolean onlyLights ){
 
 		/* ydnar: gs mods: bias texture shift */
 		if ( si->globalTexture == qfalse ) {
-			shift[ 0 ] -= ( floor( shift[ 0 ] / si->shaderWidth ) * si->shaderWidth );
-			shift[ 1 ] -= ( floor( shift[ 1 ] / si->shaderHeight ) * si->shaderHeight );
+			if ( si->shaderWidth > 0 ) {
+				shift[ 0 ] -= ( floor( shift[ 0 ] / si->shaderWidth ) * si->shaderWidth );
+			}
+			if ( si->shaderHeight ) {
+				shift[ 1 ] -= ( floor( shift[ 1 ] / si->shaderHeight ) * si->shaderHeight );
+			}
 		}
 
 		/*


### PR DESCRIPTION
I'd welcome a sanity check whether it's plausible to have shader widths or heights that are zero. I'm seeing such situations in our set of maps, but I wonder if that's a bug in our map generation.