### PR TITLE
use shader name instead of editor image in *BITMAP field on ASE export

### DIFF
--- a/tools/quake3/q3map2/convert_ase.c
+++ b/tools/quake3/q3map2/convert_ase.c
@@ -272,7 +272,7 @@ static void ConvertShader( FILE *f, bspShader_t *shader, int shaderNum ){
 	fprintf( f, "\t\t\t*MAP_SUBNO\t1\r\n" );
 	fprintf( f, "\t\t\t*MAP_AMOUNT\t1.0\r\n" );
 	fprintf( f, "\t\t\t*MAP_TYPE\tScreen\r\n" );
-	fprintf( f, "\t\t\t*BITMAP\t\"..\\%s\"\r\n", filename );
+	fprintf( f, "\t\t\t*BITMAP\t\"..\\%s\"\r\n", shader->shader );
 	fprintf( f, "\t\t\t*BITMAP_FILTER\tPyramidal\r\n" );
 	fprintf( f, "\t\t}\r\n" );
 

--- a/tools/quake3/q3map2/convert_ase.c
+++ b/tools/quake3/q3map2/convert_ase.c
@@ -272,7 +272,7 @@ static void ConvertShader( FILE *f, bspShader_t *shader, int shaderNum ){
 	fprintf( f, "\t\t\t*MAP_SUBNO\t1\r\n" );
 	fprintf( f, "\t\t\t*MAP_AMOUNT\t1.0\r\n" );
 	fprintf( f, "\t\t\t*MAP_TYPE\tScreen\r\n" );
-	fprintf( f, "\t\t\t*BITMAP\t\"..\\%s\"\r\n", shader->shader );
+	fprintf( f, "\t\t\t*BITMAP\t\"%s\"\r\n", shader->shader );
 	fprintf( f, "\t\t\t*BITMAP_FILTER\tPyramidal\r\n" );
 	fprintf( f, "\t\t}\r\n" );
 

--- a/tools/urt/tools/quake3/q3map2/convert_ase.c
+++ b/tools/urt/tools/quake3/q3map2/convert_ase.c
@@ -272,7 +272,7 @@ static void ConvertShader( FILE *f, bspShader_t *shader, int shaderNum ){
 	fprintf( f, "\t\t\t*MAP_SUBNO\t1\r\n" );
 	fprintf( f, "\t\t\t*MAP_AMOUNT\t1.0\r\n" );
 	fprintf( f, "\t\t\t*MAP_TYPE\tScreen\r\n" );
-	fprintf( f, "\t\t\t*BITMAP\t\"..\\%s\"\r\n", filename );
+	fprintf( f, "\t\t\t*BITMAP\t\"..\\%s\"\r\n", shader->shader );
 	fprintf( f, "\t\t\t*BITMAP_FILTER\tPyramidal\r\n" );
 	fprintf( f, "\t\t}\r\n" );
 

--- a/tools/urt/tools/quake3/q3map2/convert_ase.c
+++ b/tools/urt/tools/quake3/q3map2/convert_ase.c
@@ -272,7 +272,7 @@ static void ConvertShader( FILE *f, bspShader_t *shader, int shaderNum ){
 	fprintf( f, "\t\t\t*MAP_SUBNO\t1\r\n" );
 	fprintf( f, "\t\t\t*MAP_AMOUNT\t1.0\r\n" );
 	fprintf( f, "\t\t\t*MAP_TYPE\tScreen\r\n" );
-	fprintf( f, "\t\t\t*BITMAP\t\"..\\%s\"\r\n", shader->shader );
+	fprintf( f, "\t\t\t*BITMAP\t\"%s\"\r\n", shader->shader );
 	fprintf( f, "\t\t\t*BITMAP_FILTER\tPyramidal\r\n" );
 	fprintf( f, "\t\t}\r\n" );
 


### PR DESCRIPTION
Fix for https://github.com/TTimo/GtkRadiant/issues/561

This fixes the issue in a way reverse of https://github.com/TTimo/GtkRadiant/pull/617 by having q3map2 use the BITMAP field for shader names instead of editor images. This is more compatible with how other programs use ASE models. An important thing to note about this fix is that it is not backwards compatible. Anyone currently using ASE models in their map that have been generated by an older version of q3map2 will need to regenerate them.