### PR TITLE
Fix over allocating vertexes for OBJ models with multiple surfaces

### DIFF
--- a/libs/picomodel/pm_obj.c
+++ b/libs/picomodel/pm_obj.c
@@ -652,8 +652,9 @@ static picoModel_t *_obj_load( PM_PARAMS_LOAD ){
 				_obj_error_return( "Error allocating surface" );
 			}
 
-			/* reset face index for surface */
+			/* reset face index and vertex index for surface */
 			curFace = 0;
+			curVertex = 0;
 
 			/* set ptr to current surface */
 			curSurface = newSurface;


### PR DESCRIPTION
Loading Wavefront OBJ models in picomodel (used by radiant and q3map2)
did not reset the surface vertex index when starting a new surface. This
caused there to be unused vertexes, equal to the number of vertexes in
all previous surfaces, at the beginning of each surface. Exponential OBJ
vertex memory usage as number of surfaces increases. It did not affect
displaying or processing the surface faces.