### PR TITLE
Simple fix for crash related to circular dependencies in local pref path.

### DIFF
--- a/radiant/error.cpp
+++ b/radiant/error.cpp
@@ -111,15 +111,24 @@ void Error( const char *error, ... ){
 		}
 	}
 
-	strcat( text, _( "An unrecoverable error has occured.\n"
-				  "Would you like to edit Preferences before exiting Radiant?" ) );
+	// If a game has been selected in the global preferences, we can let
+	// the player edit that game's preferences to try to get it to work.
+	if (g_PrefsDlg.m_bSetGame) {
+		strcat( text, _( "An unrecoverable error has occured.\n"
+					"Would you like to edit Preferences before exiting Radiant?" ) );
 
-	Sys_Printf( text );
+		Sys_Printf( text );
 
-	if ( gtk_MessageBox( NULL, text, _( "Error" ), MB_YESNO ) == IDYES ) {
-		Sys_Printf( "Doing prefs..\n" );
-		g_PrefsDlg.LoadPrefs();
-		g_PrefsDlg.DoModal();
+		if ( gtk_MessageBox( NULL, text, _( "Error" ), MB_YESNO ) == IDYES ) {
+			Sys_Printf( "Doing prefs..\n" );
+			g_PrefsDlg.LoadPrefs();
+			g_PrefsDlg.DoModal();
+		}
+	}
+	else {
+		strcat( text, _( "An unrecoverable error has occured." ) );
+		Sys_Printf( text );
+		gtk_MessageBox( NULL, text, _( "Error" ), MB_ICONEXCLAMATION );
 	}
 
 	QGL_Shutdown();


### PR DESCRIPTION
Hi folks,

I've just added some simple logic to Error() to prevent it from trying to allow the editing of a local preferences file in the absence of any games. This addresses my encounters related to #485 .

I don't know if it's a complete fix for the issue, but it seems like a good idea.
