### PR TITLE
q3map2: do not affect styled lightmaps by floodlight, fix #616

### DIFF
--- a/tools/quake3/q3map2/light_ydnar.c
+++ b/tools/quake3/q3map2/light_ydnar.c
@@ -4109,6 +4109,9 @@ float FloodLightForSample( trace_t *trace ){
 		/* set endpoint */
 		VectorMA( trace->origin, dd, direction, trace->end );
 
+		if( lm->styles[lightmapNum] != LS_NORMAL && lm->styles[lightmapNum] != LS_NONE ) // isStyleLight
+			continue;
+
 		//VectorMA( trace->origin, 1, direction, trace->origin );
 
 		SetupTrace( trace );


### PR DESCRIPTION
Fix issue introduced in #605 and reported by @Aciz in #616.

> port of https://github.com/id-tech-3-tools/map-compiler/pull/12
> https://github.com/id-tech-3-tools/map-compiler/commit/87b8589a3a5069c482243bb33c587fc18911746c

Sorry for the very long time without news. I basically lost motivation to work on NetRadiant / GtkRadiant q3map2 merge when I discovered [that other fork](https://github.com/Garux/netradiant-custom/issues/7) requiring yet another “full time job” to merge, and when I discovered that other fork objectively reported the merge effort to others (even justifying this by taking example from the hard work I was doing on that Gtk/Net q3map2 merge). As my time is precious, I cannot let others decide on it.

Anyway, this fix was implemented by @Garux in that fork and I already merged it in NetRadiant upstream, so you may be happy to get it in GtkRadiant as well. @Aciz [said](https://github.com/TTimo/GtkRadiant/issues/616#issuecomment-633151838) “this patch is enough to solve the main issue”.