### PR TITLE
Revert "q3map2	* fix: do not affect styled lightmaps by floodlight", fix #654

### DIFF
--- a/tools/quake3/q3map2/light_ydnar.c
+++ b/tools/quake3/q3map2/light_ydnar.c
@@ -4109,9 +4109,6 @@ float FloodLightForSample( trace_t *trace ){
 		/* set endpoint */
 		VectorMA( trace->origin, dd, direction, trace->end );
 
-		if( lm->styles[lightmapNum] != LS_NORMAL && lm->styles[lightmapNum] != LS_NONE ) // isStyleLight
-			continue;
-
 		//VectorMA( trace->origin, 1, direction, trace->origin );
 
 		SetupTrace( trace );


### PR DESCRIPTION
This reverts commit 090fbf3d0ddd3472615f249d7215421fc67b313b. The broken code is not there yet and therefore cannot be fixed yet.

See #654:

> Hmm, something weird happened with my workspace. Because of Python3 issue with Scons, I made some python fixes to be able to build the tree again (similar to #651 I haven't yet seen at the time), so basically I wanted to merge the commit above my Python3 branch, check the build, then cherry-pick the commit into a feature branch to ship it on master. It looks like at some point I did something wrong at some merge or cherry-picking step and in fact the branches I built did not included the commit…
> 
> Obviously the patch does not apply, I'm surprised it technically applied. In fact it looks like the part of floodlight code that is known to be broken is not yet merged to master so the fix does not apply yet.

@TTimo I created this PR to save you time, but to avoid adding a noisy merge commit, you may select « Rebase and merge » at merge time (drop down arrow on the right of the merge button).