### PR TITLE
Fix build error on Linux due to missing `<stdint.h>` include

### DIFF
--- a/tools/quake3/common/threads.c
+++ b/tools/quake3/common/threads.c
@@ -26,6 +26,8 @@
 #include <pthread.h>
 #endif
 
+#include <stdint.h>
+
 #include "cmdlib.h"
 #include "mathlib.h"
 #include "inout.h"


### PR DESCRIPTION
This closes #662.

**Note:** Only tested on Linux/GCC, not other compilers.

I get another error when continuing the build, but I still get a working `q3map2` binary in the `install` folder:

```
❯ scons target="q3map2,q3data"
scons: Reading SConscript files ...
reading saved configuration from site.conf
saving updated configuration
emit build rules
emit configuration: config: target=['q3map2', 'q3data', ''] config=['release']
parse /home/hugo/Documents/Git/TTimo/GtkRadiant/tools/quake3/common/quake3-common.vcxproj
10 source files
parse /home/hugo/Documents/Git/TTimo/GtkRadiant/libs/mathlib/mathlib.vcxproj
4 source files
parse /home/hugo/Documents/Git/TTimo/GtkRadiant/libs/l_net/l_net.vcxproj
2 source files
parse /home/hugo/Documents/Git/TTimo/GtkRadiant/libs/ddslib/ddslib.vcxproj
1 source files
parse /home/hugo/Documents/Git/TTimo/GtkRadiant/libs/picomodel/picomodel.vcxproj
23 source files
parse /home/hugo/Documents/Git/TTimo/GtkRadiant/libs/md5lib/md5lib.vcxproj
2 source files
parse /home/hugo/Documents/Git/TTimo/GtkRadiant/tools/quake3/q3map2/q3map2.vcxproj
44 source files
parse /home/hugo/Documents/Git/TTimo/GtkRadiant/tools/quake3/common/quake3-common.vcxproj
10 source files
parse /home/hugo/Documents/Git/TTimo/GtkRadiant/libs/mathlib/mathlib.vcxproj
4 source files
parse /home/hugo/Documents/Git/TTimo/GtkRadiant/libs/l_net/l_net.vcxproj
2 source files
parse /home/hugo/Documents/Git/TTimo/GtkRadiant/libs/ddslib/ddslib.vcxproj
1 source files
parse /home/hugo/Documents/Git/TTimo/GtkRadiant/libs/picomodel/picomodel.vcxproj
23 source files
parse /home/hugo/Documents/Git/TTimo/GtkRadiant/libs/md5lib/md5lib.vcxproj
2 source files
parse /home/hugo/Documents/Git/TTimo/GtkRadiant/tools/urt/tools/quake3/q3map2/q3map2_urt.vcxproj
38 source files
parse /home/hugo/Documents/Git/TTimo/GtkRadiant/libs/mathlib/mathlib.vcxproj
4 source files
parse /home/hugo/Documents/Git/TTimo/GtkRadiant/libs/l_net/l_net.vcxproj
2 source files
parse /home/hugo/Documents/Git/TTimo/GtkRadiant/libs/ddslib/ddslib.vcxproj
1 source files
parse /home/hugo/Documents/Git/TTimo/GtkRadiant/tools/quake3/q3data/q3data.vcxproj
19 source files
scons: done reading SConscript files.
scons: Building targets ...
scons: `install/q3map2' is up to date.
scons: `install/q3map2_urt' is up to date.
scons: `install/q3data' is up to date.
FinishBuild(["finish"], [])
Lookup and bundle the PNG and JPEG libraries
ldd: install/modules/image.so: No such file or directory
ldd failed with error code 1 and output:b''
scons: *** [finish] AssertionError : 
Traceback (most recent call last):
  File "/home/hugo/Documents/Git/TTimo/GtkRadiant/config.py", line 414, in FinishBuild
    module_ldd = subprocess.check_output( ['ldd', '-r', 'install/modules/image.so'] ).decode( 'utf-8' )
  File "/home/hugo/.pyenv/versions/3.9.0/lib/python3.9/subprocess.py", line 420, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/home/hugo/.pyenv/versions/3.9.0/lib/python3.9/subprocess.py", line 524, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['ldd', '-r', 'install/modules/image.so']' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/hugo/.pyenv/versions/3.9.0/lib/python3.9/site-packages/SCons/Action.py", line 1280, in execute
    result = self.execfunction(target=target, source=rsources, env=env)
  File "/home/hugo/Documents/Git/TTimo/GtkRadiant/config.py", line 417, in FinishBuild
    assert( False )
AssertionError
scons: building terminated because of errors.
```

I suppose it's not related to the original bug report.