### PR TITLE
Do not do `using namespace std` to avoid type conflict

### DIFF
--- a/contrib/bobtoolz/DBrush.cpp
+++ b/contrib/bobtoolz/DBrush.cpp
@@ -70,12 +70,12 @@ int DBrush::BuildPoints(){
 		return 0;                   // with only 3 faces u can't have a bounded soild
 
 	}
-	for ( list<DPlane *>::const_iterator p1 = faceList.begin(); p1 != faceList.end(); p1++ )
+	for ( std::list<DPlane *>::const_iterator p1 = faceList.begin(); p1 != faceList.end(); p1++ )
 	{
-		list<DPlane *>::const_iterator p2 = p1;
+		std::list<DPlane *>::const_iterator p2 = p1;
 		for ( p2++; p2 != faceList.end(); p2++ )
 		{
-			list<DPlane *>::const_iterator p3 = p2;
+			std::list<DPlane *>::const_iterator p3 = p2;
 			for ( p3++; p3 != faceList.end(); p3++ )
 			{
 				vec3_t pnt;
@@ -135,7 +135,7 @@ void DBrush::LoadFromBrush_t( brush_t* brush, bool textured ){
 int DBrush::PointPosition( vec3_t pnt ){
 	int state = POINT_IN_BRUSH; // if nothing happens point is inside brush
 
-	for ( list<DPlane *>::const_iterator chkPlane = faceList.begin(); chkPlane != faceList.end(); chkPlane++ )
+	for ( std::list<DPlane *>::const_iterator chkPlane = faceList.begin(); chkPlane != faceList.end(); chkPlane++ )
 	{
 		float dist = ( *chkPlane )->DistanceToPoint( pnt );
 
@@ -152,7 +152,7 @@ int DBrush::PointPosition( vec3_t pnt ){
 }
 
 void DBrush::ClearPoints(){
-	for ( list<DPoint *>::const_iterator deadPoint = pointList.begin(); deadPoint != pointList.end(); deadPoint++ ) {
+	for ( std::list<DPoint *>::const_iterator deadPoint = pointList.begin(); deadPoint != pointList.end(); deadPoint++ ) {
 		delete *deadPoint;
 	}
 	pointList.clear();
@@ -160,7 +160,7 @@ void DBrush::ClearPoints(){
 
 void DBrush::ClearFaces(){
 	bBoundsBuilt = FALSE;
-	for ( list<DPlane *>::const_iterator deadPlane = faceList.begin(); deadPlane != faceList.end(); deadPlane++ )
+	for ( std::list<DPlane *>::const_iterator deadPlane = faceList.begin(); deadPlane != faceList.end(); deadPlane++ )
 	{
 		delete *deadPlane;
 	}
@@ -174,7 +174,7 @@ void DBrush::AddPoint( vec3_t pnt ){
 }
 
 bool DBrush::HasPoint( vec3_t pnt ){
-	for ( list<DPoint *>::const_iterator chkPoint = pointList.begin(); chkPoint != pointList.end(); chkPoint++ )
+	for ( std::list<DPoint *>::const_iterator chkPoint = pointList.begin(); chkPoint != pointList.end(); chkPoint++ )
 	{
 		if ( **chkPoint == pnt ) {
 			return TRUE;
@@ -186,14 +186,14 @@ bool DBrush::HasPoint( vec3_t pnt ){
 
 int DBrush::RemoveRedundantPlanes(){
 	int cnt = 0;
-	list<DPlane *>::iterator chkPlane;
+	std::list<DPlane *>::iterator chkPlane;
 
 	// find duplicate planes
-	list<DPlane *>::iterator p1 = faceList.begin();
+	std::list<DPlane *>::iterator p1 = faceList.begin();
 
 	while ( p1 != faceList.end() )
 	{
-		list<DPlane *>::iterator p2 = p1;
+		std::list<DPlane *>::iterator p2 = p1;
 
 		for ( p2++; p2 != faceList.end(); p2++ )
 		{
@@ -299,7 +299,7 @@ bool DBrush::BBoxCollision( DBrush* chkBrush ){
 }
 
 DPlane* DBrush::HasPlane( DPlane* chkPlane ){
-	for ( list<DPlane *>::const_iterator brushPlane = faceList.begin(); brushPlane != faceList.end(); brushPlane++ )
+	for ( std::list<DPlane *>::const_iterator brushPlane = faceList.begin(); brushPlane != faceList.end(); brushPlane++ )
 	{
 		if ( **brushPlane == *chkPlane ) {
 			return *brushPlane;
@@ -317,7 +317,7 @@ bool DBrush::IsCutByPlane( DPlane *cuttingPlane ){
 		}
 	}
 
-	list<DPoint *>::const_iterator chkPnt = pointList.begin();
+	std::list<DPoint *>::const_iterator chkPnt = pointList.begin();
 
 	if ( chkPnt == pointList.end() ) {
 		return FALSE;
@@ -361,7 +361,7 @@ brush_t* DBrush::BuildInRadiant( bool allowDestruction, int* changeCnt, entity_t
 	if ( allowDestruction ) {
 		bool kill = TRUE;
 
-		for ( list<DPlane *>::const_iterator chkPlane = faceList.begin(); chkPlane != faceList.end(); chkPlane++ )
+		for ( std::list<DPlane *>::const_iterator chkPlane = faceList.begin(); chkPlane != faceList.end(); chkPlane++ )
 		{
 			if ( ( *chkPlane )->m_bChkOk ) {
 				kill = FALSE;
@@ -382,7 +382,7 @@ brush_t* DBrush::BuildInRadiant( bool allowDestruction, int* changeCnt, entity_t
 
 	QER_brush = (brush_t*)g_FuncTable.m_pfnCreateBrushHandle();
 
-	for ( list<DPlane *>::const_iterator buildPlane = faceList.begin(); buildPlane != faceList.end(); buildPlane++ ) {
+	for ( std::list<DPlane *>::const_iterator buildPlane = faceList.begin(); buildPlane != faceList.end(); buildPlane++ ) {
 		if ( ( *buildPlane )->AddToBrush_t( QER_brush ) && changeCnt ) {
 			( *changeCnt )++;
 		}
@@ -410,7 +410,7 @@ void DBrush::CutByPlane( DPlane *cutPlane, DBrush **newBrush1, DBrush **newBrush
 	DBrush* b1 = new DBrush;
 	DBrush* b2 = new DBrush;
 
-	for ( list<DPlane *>::const_iterator parsePlane = faceList.begin(); parsePlane != faceList.end(); parsePlane++ )
+	for ( std::list<DPlane *>::const_iterator parsePlane = faceList.begin(); parsePlane != faceList.end(); parsePlane++ )
 	{
 		b1->AddFace( ( *parsePlane )->points[0], ( *parsePlane )->points[1], ( *parsePlane )->points[2], NULL );
 		b2->AddFace( ( *parsePlane )->points[0], ( *parsePlane )->points[1], ( *parsePlane )->points[2], NULL );
@@ -443,13 +443,13 @@ bool DBrush::IntersectsWith( DBrush *chkBrush ){
 		return FALSE;
 	}
 
-	list<DPlane *>::const_iterator iplPlane;
+	std::list<DPlane *>::const_iterator iplPlane;
 
 	for ( iplPlane = faceList.begin(); iplPlane != faceList.end(); iplPlane++ )
 	{
 
 		bool allInFront = TRUE;
-		for ( list<DPoint *>::const_iterator iPoint = chkBrush->pointList.begin(); iPoint != chkBrush->pointList.end(); iPoint++ )
+		for ( std::list<DPoint *>::const_iterator iPoint = chkBrush->pointList.begin(); iPoint != chkBrush->pointList.end(); iPoint++ )
 		{
 			if ( ( *iplPlane )->DistanceToPoint( ( *iPoint )->_pnt ) < -MAX_ROUND_ERROR ) {
 				allInFront = FALSE;
@@ -464,7 +464,7 @@ bool DBrush::IntersectsWith( DBrush *chkBrush ){
 	for ( iplPlane = chkBrush->faceList.begin(); iplPlane != chkBrush->faceList.end(); iplPlane++ )
 	{
 		bool allInFront = TRUE;
-		for ( list<DPoint *>::const_iterator iPoint = pointList.begin(); iPoint != pointList.end(); iPoint++ )
+		for ( std::list<DPoint *>::const_iterator iPoint = pointList.begin(); iPoint != pointList.end(); iPoint++ )
 		{
 			if ( ( *iplPlane )->DistanceToPoint( ( *iPoint )->_pnt ) < -MAX_ROUND_ERROR ) {
 				allInFront = FALSE;
@@ -482,7 +482,7 @@ bool DBrush::IntersectsWith( DBrush *chkBrush ){
 bool DBrush::IntersectsWith( DPlane* p1, DPlane* p2, vec3_t v ) {
 	vec3_t vDown = { 0, 0, -1 };
 
-	list<DPlane *>::const_iterator iplPlane;
+	std::list<DPlane *>::const_iterator iplPlane;
 	for ( iplPlane = faceList.begin(); iplPlane != faceList.end(); iplPlane++ ) {
 		DPlane* p = ( *iplPlane );
 
@@ -508,11 +508,11 @@ void DBrush::BuildBounds(){
 			}
 		}
 
-		list<DPoint *>::const_iterator first = pointList.begin();
+		std::list<DPoint *>::const_iterator first = pointList.begin();
 		VectorCopy( ( *first )->_pnt, bbox_min );
 		VectorCopy( ( *first )->_pnt, bbox_max );
 
-		list<DPoint *>::const_iterator point = pointList.begin();
+		std::list<DPoint *>::const_iterator point = pointList.begin();
 		for ( point++; point != pointList.end(); point++ )
 		{
 			if ( ( *point )->_pnt[0] > bbox_max[0] ) {
@@ -600,13 +600,13 @@ bool DBrush::BBoxTouch( DBrush *chkBrush ){
 	return TRUE;
 }
 
-void DBrush::ResetChecks( list<Str>* exclusionList ){
-	for ( list<DPlane *>::const_iterator resetPlane = faceList.begin(); resetPlane != faceList.end(); resetPlane++ )
+void DBrush::ResetChecks( std::list<Str>* exclusionList ){
+	for ( std::list<DPlane *>::const_iterator resetPlane = faceList.begin(); resetPlane != faceList.end(); resetPlane++ )
 	{
 		bool set = FALSE;
 
 		if ( exclusionList ) {
-			for ( list<Str>::iterator eTexture = exclusionList->begin(); eTexture != exclusionList->end(); eTexture++ )
+			for ( std::list<Str>::iterator eTexture = exclusionList->begin(); eTexture != exclusionList->end(); eTexture++ )
 			{
 				if ( strstr( ( *resetPlane )->texInfo.m_TextureName, eTexture->GetBuffer() ) ) {
 					set = TRUE;
@@ -620,7 +620,7 @@ void DBrush::ResetChecks( list<Str>* exclusionList ){
 }
 
 DPlane* DBrush::HasPlaneInverted( DPlane *chkPlane ){
-	for ( list<DPlane *>::const_iterator brushPlane = faceList.begin(); brushPlane != faceList.end(); brushPlane++ )
+	for ( std::list<DPlane *>::const_iterator brushPlane = faceList.begin(); brushPlane != faceList.end(); brushPlane++ )
 	{
 		if ( **brushPlane != *chkPlane ) {
 			if ( fabs( ( *brushPlane )->_d + chkPlane->_d ) < 0.1 ) {
@@ -632,7 +632,7 @@ DPlane* DBrush::HasPlaneInverted( DPlane *chkPlane ){
 }
 
 bool DBrush::HasTexture( const char *textureName ){
-	for ( list<DPlane *>::const_iterator chkPlane = faceList.begin(); chkPlane != faceList.end(); chkPlane++ )
+	for ( std::list<DPlane *>::const_iterator chkPlane = faceList.begin(); chkPlane != faceList.end(); chkPlane++ )
 	{
 		if ( strstr( ( *chkPlane )->texInfo.m_TextureName, textureName ) ) {
 			return TRUE;
@@ -643,7 +643,7 @@ bool DBrush::HasTexture( const char *textureName ){
 }
 
 bool DBrush::IsDetail(){
-	for ( list<DPlane *>::const_iterator chkPlane = faceList.begin(); chkPlane != faceList.end(); chkPlane++ )
+	for ( std::list<DPlane *>::const_iterator chkPlane = faceList.begin(); chkPlane != faceList.end(); chkPlane++ )
 	{
 		if ( ( *chkPlane )->texInfo.m_nContents & FACE_DETAIL ) {
 			return TRUE;
@@ -681,7 +681,7 @@ void DBrush::BuildFromWinding( DWinding *w ){
 void DBrush::SaveToFile( FILE *pFile ){
 	fprintf( pFile, "{\n" );
 
-	for ( list<DPlane *>::const_iterator pp = faceList.begin(); pp != faceList.end(); pp++ )
+	for ( std::list<DPlane *>::const_iterator pp = faceList.begin(); pp != faceList.end(); pp++ )
 	{
 		char buffer[512];
 
@@ -701,7 +701,7 @@ void DBrush::SaveToFile( FILE *pFile ){
 }
 
 void DBrush::Rotate( vec3_t vOrigin, vec3_t vRotation ){
-	for ( list<DPlane *>::const_iterator rotPlane = faceList.begin(); rotPlane != faceList.end(); rotPlane++ )
+	for ( std::list<DPlane *>::const_iterator rotPlane = faceList.begin(); rotPlane != faceList.end(); rotPlane++ )
 	{
 		for ( int i = 0; i < 3; i++ )
 			VectorRotate( ( *rotPlane )->points[i], vRotation, vOrigin );
@@ -723,7 +723,7 @@ bool DBrush::ResetTextures( const char* textureName, float fScale[2],    float f
 							int bResetTextureName,   int bResetScale[2], int bResetShift[2], int bResetRotation ){
 	if ( textureName ) {
 		bool changed = FALSE;
-		for ( list<DPlane *>::const_iterator resetPlane = faceList.begin(); resetPlane != faceList.end(); resetPlane++ )
+		for ( std::list<DPlane *>::const_iterator resetPlane = faceList.begin(); resetPlane != faceList.end(); resetPlane++ )
 		{
 			if ( !strcmp( ( *resetPlane )->texInfo.m_TextureName, textureName ) ) {
 				if ( bResetTextureName ) {
@@ -755,7 +755,7 @@ bool DBrush::ResetTextures( const char* textureName, float fScale[2],    float f
 	}
 	else
 	{
-		for ( list<DPlane *>::const_iterator resetPlane = faceList.begin(); resetPlane != faceList.end(); resetPlane++ )
+		for ( std::list<DPlane *>::const_iterator resetPlane = faceList.begin(); resetPlane != faceList.end(); resetPlane++ )
 		{
 			if ( bResetTextureName ) {
 				strcpy( ( *resetPlane )->texInfo.m_TextureName, newTextureName );
@@ -784,7 +784,7 @@ bool DBrush::ResetTextures( const char* textureName, float fScale[2],    float f
 }
 
 bool DBrush::operator ==( DBrush* other ){
-	list<DPlane *>::const_iterator chkPlane;
+	std::list<DPlane *>::const_iterator chkPlane;
 
 	for ( chkPlane = faceList.begin(); chkPlane != faceList.end(); chkPlane++ )
 	{
@@ -814,7 +814,7 @@ DPlane* DBrush::AddFace( vec3_t va, vec3_t vb, vec3_t vc, const char *textureNam
 DPlane* DBrush::FindPlaneWithClosestNormal( vec_t* normal ) {
 	vec_t bestDot = -2;
 	DPlane* bestDotPlane = NULL;
-	list<DPlane *>::const_iterator chkPlane;
+	std::list<DPlane *>::const_iterator chkPlane;
 	for ( chkPlane = faceList.begin(); chkPlane != faceList.end(); chkPlane++ ) {
 		DPlane* pPlane = ( *chkPlane );
 
@@ -837,7 +837,7 @@ int DBrush::FindPointsForPlane( DPlane* plane, DPoint** pnts, int maxpnts ) {
 
 	BuildPoints();
 
-	for ( list<DPoint *>::const_iterator points = pointList.begin(); points != pointList.end(); points++ ) {
+	for ( std::list<DPoint *>::const_iterator points = pointList.begin(); points != pointList.end(); points++ ) {
 		DPoint* point = ( *points );
 
 		if ( fabs( plane->DistanceToPoint( point->_pnt ) ) < MAX_ROUND_ERROR ) {
@@ -856,7 +856,7 @@ int DBrush::FindPointsForPlane( DPlane* plane, DPoint** pnts, int maxpnts ) {
 
 void DBrush::RemovePlane( DPlane* plane ) {
 	bBoundsBuilt = FALSE;
-	for ( list<DPlane *>::const_iterator deadPlane = faceList.begin(); deadPlane != faceList.end(); deadPlane++ ) {
+	for ( std::list<DPlane *>::const_iterator deadPlane = faceList.begin(); deadPlane != faceList.end(); deadPlane++ ) {
 		if ( *deadPlane == plane ) {
 			delete *deadPlane;
 			faceList.remove( plane );

--- a/contrib/bobtoolz/DBrush.h
+++ b/contrib/bobtoolz/DBrush.h
@@ -63,7 +63,7 @@ void BuildBounds();
 void BuildFromWinding( DWinding* w );
 brush_t* BuildInRadiant( bool allowDestruction, int* changeCnt, entity_t* entity = NULL );
 
-void ResetChecks( list<Str>* exclusionList );
+void ResetChecks( std::list<Str>* exclusionList );
 
 void ClearFaces();
 void ClearPoints();
@@ -89,8 +89,8 @@ bool operator==( DBrush* other );
 
 //	members
 brush_t* QER_brush;
-list<DPlane*> faceList;
-list<DPoint*> pointList;
+std::list<DPlane*> faceList;
+std::list<DPoint*> pointList;
 int m_nBrushID;
 vec3_t bbox_min, bbox_max;
 bool bBoundsBuilt;

--- a/contrib/bobtoolz/DEntity.cpp
+++ b/contrib/bobtoolz/DEntity.cpp
@@ -74,7 +74,7 @@ DEntity::~DEntity(){
 //////////////////////////////////////////////////////////////////////
 
 void DEntity::ClearBrushes(){
-	for ( list<DBrush *>::const_iterator deadBrush = brushList.begin(); deadBrush != brushList.end(); deadBrush++ )
+	for ( std::list<DBrush *>::const_iterator deadBrush = brushList.begin(); deadBrush != brushList.end(); deadBrush++ )
 	{
 		delete *deadBrush;
 	}
@@ -82,7 +82,7 @@ void DEntity::ClearBrushes(){
 }
 
 void DEntity::ClearPatches(){
-	for ( list<DPatch *>::const_iterator deadPatch = patchList.begin(); deadPatch != patchList.end(); deadPatch++ )
+	for ( std::list<DPatch *>::const_iterator deadPatch = patchList.begin(); deadPatch != patchList.end(); deadPatch++ )
 	{
 		delete *deadPatch;
 	}
@@ -183,7 +183,7 @@ DPlane* DEntity::AddFaceToBrush( vec3_t va, vec3_t vb, vec3_t vc, _QERFaceData* 
 DBrush* DEntity::GetBrushForID( int ID ){
 	DBrush* buildBrush = NULL;
 
-	for ( list<DBrush *>::const_iterator chkBrush = brushList.begin(); chkBrush != brushList.end(); chkBrush++ )
+	for ( std::list<DBrush *>::const_iterator chkBrush = brushList.begin(); chkBrush != brushList.end(); chkBrush++ )
 	{
 		if ( ( *chkBrush )->m_nBrushID == ID ) {
 			buildBrush = ( *chkBrush );
@@ -245,9 +245,9 @@ bool* DEntity::BuildIntersectList(){
 	bool* pbIntList = new bool[max];
 	memset( pbIntList, 0, sizeof( bool ) * ( max ) );
 
-	for ( list<DBrush *>::const_iterator pB1 = brushList.begin(); pB1 != brushList.end(); pB1++ )
+	for ( std::list<DBrush *>::const_iterator pB1 = brushList.begin(); pB1 != brushList.end(); pB1++ )
 	{
-		list<DBrush *>::const_iterator pB2 = pB1;
+		std::list<DBrush *>::const_iterator pB2 = pB1;
 		for ( pB2++; pB2 != brushList.end(); pB2++ )
 		{
 			if ( ( *pB1 )->IntersectsWith( ( *pB2 ) ) ) {
@@ -269,9 +269,9 @@ bool* DEntity::BuildDuplicateList(){
 	bool* pbDupList = new bool[max];
 	memset( pbDupList, 0, sizeof( bool ) * ( max ) );
 
-	for ( list<DBrush *>::const_iterator pB1 = brushList.begin(); pB1 != brushList.end(); pB1++ )
+	for ( std::list<DBrush *>::const_iterator pB1 = brushList.begin(); pB1 != brushList.end(); pB1++ )
 	{
-		list<DBrush *>::const_iterator pB2 = pB1;
+		std::list<DBrush *>::const_iterator pB2 = pB1;
 		for ( pB2++; pB2 != brushList.end(); pB2++ )
 		{
 			if ( **pB1 == *pB2 ) {
@@ -293,7 +293,7 @@ void DEntity::SelectBrushes( bool *selectList ){
 
 	g_FuncTable.m_pfnAllocateActiveBrushHandles();
 
-	for ( list<DBrush *>::const_iterator pBrush = brushList.begin(); pBrush != brushList.end(); pBrush++ )
+	for ( std::list<DBrush *>::const_iterator pBrush = brushList.begin(); pBrush != brushList.end(); pBrush++ )
 	{
 		if ( selectList[( *pBrush )->m_nBrushID] ) {
 			g_FuncTable.m_pfnSelectBrush( ( *pBrush )->QER_brush );
@@ -360,8 +360,8 @@ bool DEntity::LoadFromEntity( entity_t* ent, bool bLoadPatches ) {
 	return TRUE;
 }
 
-void DEntity::RemoveNonCheckBrushes( list<Str>* exclusionList, bool useDetail ){
-	list<DBrush *>::iterator chkBrush = brushList.begin();
+void DEntity::RemoveNonCheckBrushes( std::list<Str>* exclusionList, bool useDetail ){
+	std::list<DBrush *>::iterator chkBrush = brushList.begin();
 
 	while ( chkBrush != brushList.end() )
 	{
@@ -373,7 +373,7 @@ void DEntity::RemoveNonCheckBrushes( list<Str>* exclusionList, bool useDetail ){
 			}
 		}
 
-		list<Str>::iterator eTexture;
+		std::list<Str>::iterator eTexture;
 
 		for ( eTexture = exclusionList->begin(); eTexture != exclusionList->end(); eTexture++ )
 		{
@@ -390,8 +390,8 @@ void DEntity::RemoveNonCheckBrushes( list<Str>* exclusionList, bool useDetail ){
 	}
 }
 
-void DEntity::ResetChecks( list<Str>* exclusionList ){
-	for ( list<DBrush *>::const_iterator resetBrush = brushList.begin(); resetBrush != brushList.end(); resetBrush++ )
+void DEntity::ResetChecks( std::list<Str>* exclusionList ){
+	for ( std::list<DBrush *>::const_iterator resetBrush = brushList.begin(); resetBrush != brushList.end(); resetBrush++ )
 	{
 		( *resetBrush )->ResetChecks( exclusionList );
 	}
@@ -402,7 +402,7 @@ int DEntity::FixBrushes( bool rebuild ){
 
 	int cnt = 0;
 
-	for ( list<DBrush *>::const_iterator fixBrush = brushList.begin(); fixBrush != brushList.end(); fixBrush++ )
+	for ( std::list<DBrush *>::const_iterator fixBrush = brushList.begin(); fixBrush != brushList.end(); fixBrush++ )
 	{
 		int count = ( *fixBrush )->RemoveRedundantPlanes();
 		if ( count ) {
@@ -430,7 +430,7 @@ void DEntity::BuildInRadiant( bool allowDestruction ){
 
 		epair_t* pEp = pEpS;
 
-		for ( list<DEPair* >::const_iterator buildEPair = epairList.begin(); buildEPair != epairList.end(); buildEPair++ )
+		for ( std::list<DEPair* >::const_iterator buildEPair = epairList.begin(); buildEPair != epairList.end(); buildEPair++ )
 		{
 			pEp = GetNextChainItem( pEp, ( *buildEPair )->key, ( *buildEPair )->value );
 		}
@@ -439,20 +439,20 @@ void DEntity::BuildInRadiant( bool allowDestruction ){
 
 		g_FuncTable.m_pfnCommitEntityHandleToMap( pE );
 
-		for ( list<DBrush *>::const_iterator buildBrush = brushList.begin(); buildBrush != brushList.end(); buildBrush++ )
+		for ( std::list<DBrush *>::const_iterator buildBrush = brushList.begin(); buildBrush != brushList.end(); buildBrush++ )
 			( *buildBrush )->BuildInRadiant( allowDestruction, NULL, pE );
 
-		for ( list<DPatch *>::const_iterator buildPatch = patchList.begin(); buildPatch != patchList.end(); buildPatch++ )
+		for ( std::list<DPatch *>::const_iterator buildPatch = patchList.begin(); buildPatch != patchList.end(); buildPatch++ )
 			( *buildPatch )->BuildInRadiant( pE );
 
 		QER_Entity = pE;
 	}
 	else
 	{
-		for ( list<DBrush *>::const_iterator buildBrush = brushList.begin(); buildBrush != brushList.end(); buildBrush++ )
+		for ( std::list<DBrush *>::const_iterator buildBrush = brushList.begin(); buildBrush != brushList.end(); buildBrush++ )
 			( *buildBrush )->BuildInRadiant( allowDestruction, NULL );
 
-		for ( list<DPatch *>::const_iterator buildPatch = patchList.begin(); buildPatch != patchList.end(); buildPatch++ )
+		for ( std::list<DPatch *>::const_iterator buildPatch = patchList.begin(); buildPatch != patchList.end(); buildPatch++ )
 			( *buildPatch )->BuildInRadiant();
 	}
 }
@@ -461,7 +461,7 @@ void DEntity::BuildInRadiant( bool allowDestruction ){
 
 int DEntity::GetIDMax( void ) {
 	int max = -1;
-	for ( list<DBrush *>::const_iterator cntBrush = brushList.begin(); cntBrush != brushList.end(); cntBrush++ ) {
+	for ( std::list<DBrush *>::const_iterator cntBrush = brushList.begin(); cntBrush != brushList.end(); cntBrush++ ) {
 		if ( ( *cntBrush )->m_nBrushID > max ) {
 			max = ( *cntBrush )->m_nBrushID;
 		}
@@ -478,12 +478,12 @@ void DEntity::SaveToFile( FILE *pFile ){
 
 	fprintf( pFile, "\"classname\" \"%s\"\n", (const char *)m_Classname );
 
-	for ( list<DEPair *>::const_iterator ep = epairList.begin(); ep != epairList.end(); ep++ )
+	for ( std::list<DEPair *>::const_iterator ep = epairList.begin(); ep != epairList.end(); ep++ )
 	{
 		fprintf( pFile, "\"%s\" \"%s\"\n", (const char *)( *ep )->key, (const char *)( *ep )->value );
 	}
 
-	for ( list<DBrush *>::const_iterator bp = brushList.begin(); bp != brushList.end(); bp++ )
+	for ( std::list<DBrush *>::const_iterator bp = brushList.begin(); bp != brushList.end(); bp++ )
 	{
 		( *bp )->SaveToFile( pFile );
 	}
@@ -492,7 +492,7 @@ void DEntity::SaveToFile( FILE *pFile ){
 }
 
 void DEntity::ClearEPairs(){
-	for ( list<DEPair *>::const_iterator deadEPair = epairList.begin(); deadEPair != epairList.end(); deadEPair++ )
+	for ( std::list<DEPair *>::const_iterator deadEPair = epairList.begin(); deadEPair != epairList.end(); deadEPair++ )
 	{
 		delete ( *deadEPair );
 	}
@@ -535,7 +535,7 @@ bool DEntity::ResetTextures( const char* textureName, float fScale[2],     float
 
 	bool reset = FALSE;
 
-	for ( list<DBrush *>::const_iterator resetBrush = brushList.begin(); resetBrush != brushList.end(); resetBrush++ )
+	for ( std::list<DBrush *>::const_iterator resetBrush = brushList.begin(); resetBrush != brushList.end(); resetBrush++ )
 	{
 		bool tmp = ( *resetBrush )->ResetTextures( textureName,        fScale,       fShift,       rotation, newTextureName,
 												   bResetTextureName,  bResetScale,  bResetShift,  bResetRotation );
@@ -555,7 +555,7 @@ bool DEntity::ResetTextures( const char* textureName, float fScale[2],     float
 	}
 
 	if ( bResetTextureName ) {
-		for ( list<DPatch *>::const_iterator resetPatch = patchList.begin(); resetPatch != patchList.end(); resetPatch++ )
+		for ( std::list<DPatch *>::const_iterator resetPatch = patchList.begin(); resetPatch != patchList.end(); resetPatch++ )
 		{
 			bool tmp = ( *resetPatch )->ResetTextures( textureName, newTextureName );
 
@@ -577,7 +577,7 @@ bool DEntity::ResetTextures( const char* textureName, float fScale[2],     float
 }
 
 DEPair* DEntity::FindEPairByKey( const char* keyname ){
-	for ( list<DEPair *>::const_iterator ep = epairList.begin(); ep != epairList.end(); ep++ )
+	for ( std::list<DEPair *>::const_iterator ep = epairList.begin(); ep != epairList.end(); ep++ )
 	{
 		char* c = ( *ep )->key;
 		if ( !strcmp( c, keyname ) ) {
@@ -638,7 +638,7 @@ int DEntity::GetBrushCount( void ) {
 }
 
 DBrush* DEntity::FindBrushByPointer( brush_t* brush ) {
-	for ( list<DBrush *>::const_iterator listBrush = brushList.begin(); listBrush != brushList.end(); listBrush++ ) {
+	for ( std::list<DBrush *>::const_iterator listBrush = brushList.begin(); listBrush != brushList.end(); listBrush++ ) {
 		DBrush* pBrush = ( *listBrush );
 		if ( pBrush->QER_brush == brush ) {
 			return pBrush;

--- a/contrib/bobtoolz/DEntity.h
+++ b/contrib/bobtoolz/DEntity.h
@@ -59,8 +59,8 @@ void SetClassname( const char* classname );
 int GetIDMax();
 
 void BuildInRadiant( bool allowDestruction );
-void ResetChecks( list<Str>* exclusionList );
-void RemoveNonCheckBrushes( list<Str>* exclusionList, bool useDetail );
+void ResetChecks( std::list<Str>* exclusionList );
+void RemoveNonCheckBrushes( std::list<Str>* exclusionList, bool useDetail );
 
 DPlane* AddFaceToBrush( vec3_t va, vec3_t vb, vec3_t vc, _QERFaceData* faceData, int ID );      // slow, try not to use much
 int GetBrushCount( void );
@@ -89,10 +89,10 @@ DPatch* NewPatch();
 //	---------------------------------------------
 
 //	vars
-list<DEPair*> epairList;
-list<DBrush*> brushList;
+std::list<DEPair*> epairList;
+std::list<DBrush*> brushList;
 // new patches, wahey!!!
-list<DPatch*> patchList;
+std::list<DPatch*> patchList;
 Str m_Classname;
 //	---------------------------------------------
 

--- a/contrib/bobtoolz/DMap.cpp
+++ b/contrib/bobtoolz/DMap.cpp
@@ -55,7 +55,7 @@ DEntity* DMap::AddEntity( const char *classname, int ID ){
 void DMap::ClearEntities(){
 	m_nNextEntity = 1;
 
-	for ( list<DEntity *>::const_iterator deadEntity = entityList.begin(); deadEntity != entityList.end(); deadEntity++ )
+	for ( std::list<DEntity *>::const_iterator deadEntity = entityList.begin(); deadEntity != entityList.end(); deadEntity++ )
 		delete *deadEntity;
 
 	entityList.clear();
@@ -64,7 +64,7 @@ void DMap::ClearEntities(){
 DEntity* DMap::GetEntityForID( int ID ){
 	DEntity* findEntity = NULL;
 
-	for ( list<DEntity *>::const_iterator chkEntity = entityList.begin(); chkEntity != entityList.end(); chkEntity++ )
+	for ( std::list<DEntity *>::const_iterator chkEntity = entityList.begin(); chkEntity != entityList.end(); chkEntity++ )
 	{
 		if ( ( *chkEntity )->m_nID == ID ) {
 			findEntity = ( *chkEntity );
@@ -85,7 +85,7 @@ DEntity* DMap::GetWorldSpawn(){
 }
 
 void DMap::BuildInRadiant( bool bAllowDestruction ){
-	for ( list<DEntity *>::const_iterator buildEntity = entityList.begin(); buildEntity != entityList.end(); buildEntity++ )
+	for ( std::list<DEntity *>::const_iterator buildEntity = entityList.begin(); buildEntity != entityList.end(); buildEntity++ )
 		( *buildEntity )->BuildInRadiant( bAllowDestruction );
 }
 
@@ -116,7 +116,7 @@ void DMap::LoadAll( bool bLoadPatches ){
 
 int DMap::FixBrushes( bool rebuild ){
 	int count = 0;
-	for ( list<DEntity *>::const_iterator fixEntity = entityList.begin(); fixEntity != entityList.end(); fixEntity++ )
+	for ( std::list<DEntity *>::const_iterator fixEntity = entityList.begin(); fixEntity != entityList.end(); fixEntity++ )
 	{
 		int cnt;
 
@@ -140,7 +140,7 @@ int DMap::FixBrushes( bool rebuild ){
 
 void DMap::ResetTextures( const char* textureName, float fScale[2],      float fShift[2],      int rotation, const char* newTextureName,
 						  int bResetTextureName,  int bResetScale[2],  int bResetShift[2],  int bResetRotation ){
-	for ( list<DEntity *>::const_iterator texEntity = entityList.begin(); texEntity != entityList.end(); texEntity++ )
+	for ( std::list<DEntity *>::const_iterator texEntity = entityList.begin(); texEntity != entityList.end(); texEntity++ )
 	{
 		if ( !stricmp( "worldspawn", ( *texEntity )->m_Classname ) ) {
 			( *texEntity )->ResetTextures( textureName,        fScale,       fShift,       rotation, newTextureName,

--- a/contrib/bobtoolz/DMap.h
+++ b/contrib/bobtoolz/DMap.h
@@ -45,7 +45,7 @@ void ClearEntities();
 DEntity* GetEntityForID( int ID );
 DEntity* AddEntity( const char* classname = "worldspawn", int ID = -1 );
 
-list<DEntity*> entityList;
+std::list<DEntity*> entityList;
 
 DMap();
 virtual ~DMap();

--- a/contrib/bobtoolz/DPatch.cpp
+++ b/contrib/bobtoolz/DPatch.cpp
@@ -335,8 +335,8 @@ void DPatch::Transpose(){
 	Invert();
 }
 
-list<DPatch> DPatch::Split( bool rows, bool cols ){
-	list<DPatch> patchList;
+std::list<DPatch> DPatch::Split( bool rows, bool cols ){
+	std::list<DPatch> patchList;
 	int i;
 	int x, y;
 
@@ -360,13 +360,13 @@ list<DPatch> DPatch::Split( bool rows, bool cols ){
 		}
 
 		if ( cols && width >= 5 ) {
-			list<DPatch> patchList2;
+			std::list<DPatch> patchList2;
 
-			for ( list<DPatch>::iterator patches = patchList.begin(); patches != patchList.end(); patches++ )
+			for ( std::list<DPatch>::iterator patches = patchList.begin(); patches != patchList.end(); patches++ )
 			{
-				list<DPatch> patchList3 = ( *patches ).Split( false, true );
+				std::list<DPatch> patchList3 = ( *patches ).Split( false, true );
 
-				for ( list<DPatch>::iterator patches2 = patchList3.begin(); patches2 != patchList3.end(); patches2++ )
+				for ( std::list<DPatch>::iterator patches2 = patchList3.begin(); patches2 != patchList3.end(); patches2++ )
 					patchList2.push_front( *patches2 );
 			}
 

--- a/contrib/bobtoolz/DPatch.h
+++ b/contrib/bobtoolz/DPatch.h
@@ -39,7 +39,7 @@ typedef struct
 class DPatch
 {
 public:
-list<DPatch> Split( bool rows, bool cols );
+std::list<DPatch> Split( bool rows, bool cols );
 void Transpose();
 void Invert();
 DPatch* MergePatches( patch_merge_t merge_info, DPatch* p1, DPatch* p2 );

--- a/contrib/bobtoolz/DPlane.cpp
+++ b/contrib/bobtoolz/DPlane.cpp
@@ -96,11 +96,11 @@ bool DPlane::PlaneIntersection( DPlane *pl1, DPlane *pl2, vec3_t out ){
 	return TRUE;
 }
 
-bool DPlane::IsRedundant( list<DPoint*>& pointList ){
+bool DPlane::IsRedundant( std::list<DPoint*>& pointList ){
 	int cnt = 0;
 
 	//list<DPoint *>::const_iterator point=pointList.begin();
-	for ( list<DPoint *>::const_iterator point = pointList.begin(); point != pointList.end(); point++ )
+	for ( std::list<DPoint *>::const_iterator point = pointList.begin(); point != pointList.end(); point++ )
 	{
 		if ( fabs( DistanceToPoint( ( *point )->_pnt ) ) < MAX_ROUND_ERROR ) {
 			cnt++;

--- a/contrib/bobtoolz/DPlane.h
+++ b/contrib/bobtoolz/DPlane.h
@@ -47,7 +47,7 @@ bool AddToBrush_t( brush_t *brush );
 bool operator !=( DPlane& other );
 bool operator ==( DPlane& other );
 
-bool IsRedundant( list<DPoint*>& pointList );
+bool IsRedundant( std::list<DPoint*>& pointList );
 bool PlaneIntersection( DPlane* pl1, DPlane* pl2, vec3_t out );;
 
 vec_t DistanceToPoint( vec3_t pnt );

--- a/contrib/bobtoolz/DTrainDrawer.cpp
+++ b/contrib/bobtoolz/DTrainDrawer.cpp
@@ -46,7 +46,7 @@ DTrainDrawer::~DTrainDrawer( void ) {
 }
 
 void DTrainDrawer::ClearSplines() {
-	for ( list<splinePoint_t *>::const_iterator deadSpline = m_splineList.begin(); deadSpline != m_splineList.end(); deadSpline++ ) {
+	for ( std::list<splinePoint_t *>::const_iterator deadSpline = m_splineList.begin(); deadSpline != m_splineList.end(); deadSpline++ ) {
 		( *deadSpline )->m_pointList.clear();
 		( *deadSpline )->m_vertexList.clear();
 		delete ( *deadSpline );
@@ -56,7 +56,7 @@ void DTrainDrawer::ClearSplines() {
 }
 
 void DTrainDrawer::ClearPoints() {
-	for ( list<controlPoint_t *>::const_iterator deadPoint = m_pointList.begin(); deadPoint != m_pointList.end(); deadPoint++ ) {
+	for ( std::list<controlPoint_t *>::const_iterator deadPoint = m_pointList.begin(); deadPoint != m_pointList.end(); deadPoint++ ) {
 		delete *deadPoint;
 	}
 
@@ -122,11 +122,11 @@ void DTrainDrawer::Draw3D() {
 
 	g_QglTable.m_pfn_qglDepthFunc( GL_ALWAYS );
 
-	for ( list<splinePoint_t* >::const_iterator sp = m_splineList.begin(); sp != m_splineList.end(); sp++ ) {
+	for ( std::list<splinePoint_t* >::const_iterator sp = m_splineList.begin(); sp != m_splineList.end(); sp++ ) {
 		splinePoint_t* pSP = ( *sp );
 
 		g_QglTable.m_pfn_qglBegin( GL_LINE_STRIP );
-		for ( list<DPoint >::const_iterator v = pSP->m_vertexList.begin(); v != pSP->m_vertexList.end(); v++ ) {
+		for ( std::list<DPoint >::const_iterator v = pSP->m_vertexList.begin(); v != pSP->m_vertexList.end(); v++ ) {
 			g_QglTable.m_pfn_qglVertex3fv( ( *v )._pnt );
 		}
 		g_QglTable.m_pfn_qglEnd();
@@ -174,11 +174,11 @@ void DTrainDrawer::Draw2D( VIEWTYPE vt ) {
 
 	g_QglTable.m_pfn_qglColor4f( 1.f, 0.f, 0.f, 1.f );
 
-	for ( list<splinePoint_t* >::const_iterator sp = m_splineList.begin(); sp != m_splineList.end(); sp++ ) {
+	for ( std::list<splinePoint_t* >::const_iterator sp = m_splineList.begin(); sp != m_splineList.end(); sp++ ) {
 		splinePoint_t* pSP = ( *sp );
 
 		g_QglTable.m_pfn_qglBegin( GL_LINE_STRIP );
-		for ( list<DPoint >::const_iterator v = pSP->m_vertexList.begin(); v != pSP->m_vertexList.end(); v++ ) {
+		for ( std::list<DPoint >::const_iterator v = pSP->m_vertexList.begin(); v != pSP->m_vertexList.end(); v++ ) {
 			g_QglTable.m_pfn_qglVertex3fv( ( *v )._pnt );
 		}
 		g_QglTable.m_pfn_qglEnd();
@@ -258,7 +258,7 @@ void DTrainDrawer::BuildPaths() {
 		}
 	}
 
-	list<splinePoint_t* >::const_iterator sp;
+	std::list<splinePoint_t* >::const_iterator sp;
 	for ( sp = m_splineList.begin(); sp != m_splineList.end(); sp++ ) {
 		splinePoint_t* pSP = ( *sp );
 
@@ -273,7 +273,7 @@ void DTrainDrawer::BuildPaths() {
 		pSP->pTarget = pTarget;
 
 
-		for ( list<controlPoint_t >::iterator cp = pSP->m_pointList.begin(); cp != pSP->m_pointList.end(); cp++ ) {
+		for ( std::list<controlPoint_t >::iterator cp = pSP->m_pointList.begin(); cp != pSP->m_pointList.end(); cp++ ) {
 			controlPoint_t* pControl = FindControlPoint( ( *cp ).strName );
 			if ( !pControl ) {
 				Sys_Printf( "couldn't find control %s", ( *cp ).strName );
@@ -301,7 +301,7 @@ void DTrainDrawer::BuildPaths() {
 		VectorCopy( pSP->point.vOrigin, v[0] );
 
 		int i = 1;
-		for ( list<controlPoint_t>::reverse_iterator cp = pSP->m_pointList.rbegin(); cp != pSP->m_pointList.rend(); cp++ ) {
+		for ( std::list<controlPoint_t>::reverse_iterator cp = pSP->m_pointList.rbegin(); cp != pSP->m_pointList.rend(); cp++ ) {
 			VectorCopy( ( *cp ).vOrigin, v[i] );
 			i++;
 		}
@@ -342,13 +342,13 @@ splinePoint_t* DTrainDrawer::AddSplinePoint( const char* name, const char* targe
 }
 
 controlPoint_t* DTrainDrawer::FindControlPoint( const char* name ){
-	for ( list<controlPoint_t*>::const_iterator cp = m_pointList.begin(); cp != m_pointList.end(); cp++ ) {
+	for ( std::list<controlPoint_t*>::const_iterator cp = m_pointList.begin(); cp != m_pointList.end(); cp++ ) {
 		if ( !strcmp( name, ( *cp )->strName ) ) {
 			return ( *cp );
 		}
 	}
 
-	for ( list<splinePoint_t*>::const_iterator sp = m_splineList.begin(); sp != m_splineList.end(); sp++ ) {
+	for ( std::list<splinePoint_t*>::const_iterator sp = m_splineList.begin(); sp != m_splineList.end(); sp++ ) {
 		if ( !strcmp( name, ( *sp )->point.strName ) ) {
 			return &( ( *sp )->point );
 		}

--- a/contrib/bobtoolz/DTrainDrawer.h
+++ b/contrib/bobtoolz/DTrainDrawer.h
@@ -43,8 +43,8 @@ typedef struct {
 	char strControl[64];
 	char strTarget[64];
 
-	list<controlPoint_t> m_pointList;
-	list<DPoint> m_vertexList;
+	std::list<controlPoint_t> m_pointList;
+	std::list<DPoint> m_vertexList;
 
 	controlPoint_t* pTarget;
 } splinePoint_t;
@@ -54,8 +54,8 @@ class DTrainDrawer :
 	public IGL3DWindow
 {
 private:
-list<splinePoint_t*> m_splineList;
-list<controlPoint_t*> m_pointList;
+std::list<splinePoint_t*> m_splineList;
+std::list<controlPoint_t*> m_pointList;
 int refCount;
 
 bool m_bHooked;

--- a/contrib/bobtoolz/DVisDrawer.cpp
+++ b/contrib/bobtoolz/DVisDrawer.cpp
@@ -84,7 +84,7 @@ void DVisDrawer::Draw2D( VIEWTYPE vt ){
 	g_QglTable.m_pfn_qglDepthFunc( GL_ALWAYS );
 
 	//bleh
-	list<DWinding *>::const_iterator l = m_list->begin();
+	std::list<DWinding *>::const_iterator l = m_list->begin();
 
 	for (; l != m_list->end(); l++ )
 	{
@@ -129,7 +129,7 @@ void DVisDrawer::Draw3D(){
 	g_QglTable.m_pfn_qglDepthFunc( GL_ALWAYS );
 
 	//bleh
-	list<DWinding *>::const_iterator l = m_list->begin();
+	std::list<DWinding *>::const_iterator l = m_list->begin();
 
 	for (; l != m_list->end(); l++ )
 	{
@@ -159,7 +159,7 @@ void DVisDrawer::UnRegister(){
 	m_bHooked = FALSE;
 }
 
-void DVisDrawer::SetList( list<DWinding*> *pointList ){
+void DVisDrawer::SetList( std::list<DWinding*> *pointList ){
 	if ( m_list ) {
 		ClearPoints();
 	}
@@ -168,7 +168,7 @@ void DVisDrawer::SetList( list<DWinding*> *pointList ){
 }
 
 void DVisDrawer::ClearPoints(){
-	list<DWinding *>::const_iterator deadPoint = m_list->begin();
+	std::list<DWinding *>::const_iterator deadPoint = m_list->begin();
 	for (; deadPoint != m_list->end(); deadPoint++ )
 		delete *deadPoint;
 	m_list->clear();

--- a/contrib/bobtoolz/DVisDrawer.h
+++ b/contrib/bobtoolz/DVisDrawer.h
@@ -40,11 +40,11 @@ DVisDrawer();
 virtual ~DVisDrawer();
 
 protected:
-list<DWinding*>* m_list;
+std::list<DWinding*>* m_list;
 int refCount;
 public:
 void ClearPoints();
-void SetList( list<DWinding*>* pointList );
+void SetList( std::list<DWinding*>* pointList );
 void UnRegister();
 void Register();
 void Draw3D();

--- a/contrib/bobtoolz/funchandlers-GTK.cpp
+++ b/contrib/bobtoolz/funchandlers-GTK.cpp
@@ -36,8 +36,8 @@
 #include "visfind.h"
 
 // for autocaulk
-list<Str> exclusionList;        // whole brush exclusion
-list<Str> exclusionList_Face;   // single face exclusion
+std::list<Str> exclusionList;        // whole brush exclusion
+std::list<Str> exclusionList_Face;   // single face exclusion
 
 bool el1Loaded =        FALSE;
 bool el2Loaded =        FALSE;
@@ -507,8 +507,8 @@ void DoSplitPatch() {
 
 	patch.LoadFromBrush_t( brush );
 
-	list<DPatch> patchList = patch.Split( true, true );
-	for ( list<DPatch>::iterator patches = patchList.begin(); patches != patchList.end(); patches++ ) {
+	std::list<DPatch> patchList = patch.Split( true, true );
+	for ( std::list<DPatch>::iterator patches = patchList.begin(); patches != patchList.end(); patches++ ) {
 		( *patches ).BuildInRadiant();
 	}
 
@@ -559,7 +559,7 @@ void DoVisAnalyse(){
 	char* ext = strrchr( filename, '.' ) + 1;
 	strcpy( ext, "bsp" ); // rename the extension
 
-	list<DWinding*> *pointList = BuildTrace( filename, origin );
+	std::list<DWinding*> *pointList = BuildTrace( filename, origin );
 
 	if ( !g_VisView ) {
 		g_VisView = new DVisDrawer;

--- a/contrib/bobtoolz/funchandlers-ctf-GTK.cpp
+++ b/contrib/bobtoolz/funchandlers-ctf-GTK.cpp
@@ -29,8 +29,8 @@
 #include "funchandlers.h"
 
 // for ctf texture changer
-list<Str> clrList_Blue;
-list<Str> clrList_Red;
+std::list<Str> clrList_Blue;
+std::list<Str> clrList_Red;
 
 BOOL clrLst1Loaded = FALSE;
 BOOL clrLst2Loaded = FALSE;
@@ -72,8 +72,8 @@ void DoCTFColourChanger(){
 
 	int cnt = Min( clrList_Blue.size(), clrList_Red.size() );
 
-	list<Str>::const_iterator Texture_change;
-	list<Str>::const_iterator Texture_new;
+	std::list<Str>::const_iterator Texture_change;
+	std::list<Str>::const_iterator Texture_new;
 
 	float fDummy[2];
 

--- a/contrib/bobtoolz/funchandlers.cpp
+++ b/contrib/bobtoolz/funchandlers.cpp
@@ -39,8 +39,8 @@
 #include "DShape.h"
 
 // for autocaulk
-list<Str> exclusionList;        // whole brush exclusion
-list<Str> exclusionList_Face;   // single face exclusion
+std::list<Str> exclusionList;        // whole brush exclusion
+std::list<Str> exclusionList_Face;   // single face exclusion
 
 BOOL el1Loaded;
 BOOL el2Loaded;

--- a/contrib/bobtoolz/lists.cpp
+++ b/contrib/bobtoolz/lists.cpp
@@ -26,7 +26,7 @@
 #include "lists.h"
 #include "misc.h"
 
-bool LoadExclusionList( char* filename, list<Str>* exclusionList ){
+bool LoadExclusionList( char* filename, std::list<Str>* exclusionList ){
 	FILE* eFile = fopen( filename, "r" );
 	if ( eFile ) {
 		char buffer[256];

--- a/contrib/bobtoolz/lists.h
+++ b/contrib/bobtoolz/lists.h
@@ -17,5 +17,5 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
 
-bool LoadExclusionList( char* filename, list<Str>* exclusionList );
+bool LoadExclusionList( char* filename, std::list<Str>* exclusionList );
 bool LoadGList( char* filename, GList** loadlist );

--- a/contrib/bobtoolz/misc.cpp
+++ b/contrib/bobtoolz/misc.cpp
@@ -265,7 +265,7 @@ void StartBSP(){
 	Q_Exec( command, TRUE );
 }
 
-void BuildMiniPrt( list<Str>* exclusionList ){
+void BuildMiniPrt( std::list<Str>* exclusionList ){
 	// yes, we could just use -fulldetail option, but, as SPOG said
 	// it'd be faster without all the hint, donotenter etc textures and
 	// doors, etc

--- a/contrib/bobtoolz/misc.h
+++ b/contrib/bobtoolz/misc.h
@@ -28,7 +28,7 @@ void FillDefaultTexture( _QERFaceData* faceData, vec3_t va, vec3_t vb, vec3_t vc
 
 void Sys_ERROR( const char* text, ... );
 
-void BuildMiniPrt( list<Str>* exclusionList );
+void BuildMiniPrt( std::list<Str>* exclusionList );
 
 void MoveBlock( int dir, vec3_t min, vec3_t max, float dist );
 void SetInitialStairPos( int dir, vec3_t min, vec3_t max, float width );

--- a/contrib/bobtoolz/visfind.cpp
+++ b/contrib/bobtoolz/visfind.cpp
@@ -125,7 +125,7 @@ int bsp_countclusters_mask( byte *bitvector, byte *maskvector, int length ){
 	return( c );
 }
 
-void AddCluster( list<DWinding*> *pointlist, dleaf_t *cl, qboolean* repeatlist, vec3_t clr ){
+void AddCluster( std::list<DWinding*> *pointlist, dleaf_t *cl, qboolean* repeatlist, vec3_t clr ){
 	DWinding*   w;
 
 	int* leafsurf = &dleafsurfaces[cl->firstLeafSurface];
@@ -169,10 +169,10 @@ void AddCluster( list<DWinding*> *pointlist, dleaf_t *cl, qboolean* repeatlist, 
    CreateTrace
    =============
  */
-list<DWinding*> *CreateTrace( dleaf_t *leaf, int c, vis_header *header, byte *visdata, byte *seen ){
+std::list<DWinding*> *CreateTrace( dleaf_t *leaf, int c, vis_header *header, byte *visdata, byte *seen ){
 	byte        *vis;
 	int i, j, clusterNum;
-	list<DWinding*> *pointlist = new list<DWinding*>;
+	std::list<DWinding*> *pointlist = new std::list<DWinding*>;
 	qboolean*   repeatlist = new qboolean[numDrawSurfaces];
 	dleaf_t     *cl;
 
@@ -219,7 +219,7 @@ list<DWinding*> *CreateTrace( dleaf_t *leaf, int c, vis_header *header, byte *vi
    setup for CreateTrace
    =============
  */
-list<DWinding*> *TraceCluster( int leafnum ){
+std::list<DWinding*> *TraceCluster( int leafnum ){
 	byte seen[( MAX_MAP_LEAFS / 8 ) + 1];
 	vis_header      *vheader;
 	byte            *visdata;
@@ -236,14 +236,14 @@ list<DWinding*> *TraceCluster( int leafnum ){
 	return CreateTrace( leaf, leaf->cluster, vheader, visdata, seen );
 }
 
-list<DWinding *>* BuildTrace( char* filename, vec3_t v_origin ){
+std::list<DWinding *>* BuildTrace( char* filename, vec3_t v_origin ){
 	if ( !LoadBSPFile( filename ) ) {
 		return NULL;
 	}
 
 	int leafnum = bsp_leafnumfororigin( v_origin );
 
-	list<DWinding*> *pointlist = TraceCluster( leafnum );
+	std::list<DWinding*> *pointlist = TraceCluster( leafnum );
 
 	FreeBSPData();
 

--- a/contrib/bobtoolz/visfind.h
+++ b/contrib/bobtoolz/visfind.h
@@ -16,4 +16,4 @@
    License along with this library; if not, write to the Free Software
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
  */
-list<DWinding*> *BuildTrace( char* filename, vec3_t v_origin );
+std::list<DWinding*> *BuildTrace( char* filename, vec3_t v_origin );

--- a/include/stl_check.h
+++ b/include/stl_check.h
@@ -29,12 +29,7 @@
 #define Q_NO_STLPORT
 #endif
 
-#ifdef Q_NO_STLPORT
-
-// not using STLPort (gcc 3.x build)
-using namespace std;
-
-#else
+#ifndef Q_NO_STLPORT
 
 #ifndef _STLPORT_VERSION
 #error "Can't find _STLPORT_VERSION, check you are compiling against STLPort"

--- a/libs/synapse.h
+++ b/libs/synapse.h
@@ -197,7 +197,7 @@ class CSynapseAPIManager : public IRefCounted
 EAPIManagerType mType;
 
 // the list of APIs we have obtained (SYN_REQUIRE_ANY)
-vector< APIDescriptor_t * > mAPIs;
+std::vector< APIDescriptor_t * > mAPIs;
 /*!
    pattern for matching the major version
    NOTE: only supported for now: exact match
@@ -289,15 +289,15 @@ bool mbActive;
 /*!
    we store APIDescriptor_t*, the module fills that in at startup
  */
-vector<APIDescriptor_t *> mAPIDescriptors;
+std::vector<APIDescriptor_t *> mAPIDescriptors;
 
 /*!
    managers for multiple APIs management
    mManagersMatch are managers with loose matching / undefined number of APIs
    mManagersList are managers with a fixed list of required interfaces
  */
-vector<CSynapseAPIManager *> mManagersMatch;
-vector<CSynapseAPIManager *> mManagersList;
+std::vector<CSynapseAPIManager *> mManagersMatch;
+std::vector<CSynapseAPIManager *> mManagersList;
 
 protected:
 friend class CSynapseServer;
@@ -492,13 +492,13 @@ virtual ~CSynapseClientSlot() { }
  */
 class CSynapseServer : public IRefCounted
 {
-list<char *> mSearchPaths;
-list<CSynapseClientSlot> mClients;
+std::list<char *> mSearchPaths;
+std::list<CSynapseClientSlot> mClients;
 
 /*!
    used for resolve operations
  */
-list<APIDescriptor_t*> mStack;
+std::list<APIDescriptor_t*> mStack;
 /*!
    set this when mStack is modified with new stuff to resolve
    NOTE: if this hack becomes too tricky to use we could just encapsulate mStack
@@ -552,7 +552,7 @@ void TryPushStack( APIDescriptor_t * );
    \param iSlot is an mClients iterator, invalid when the function returns as the item will have been removed from the list
    \return the iterator after erase call so that the caller iteration can continue
  */
-list<CSynapseClientSlot>::iterator ShutdownClient( list<CSynapseClientSlot>::iterator iSlot );
+std::list<CSynapseClientSlot>::iterator ShutdownClient( std::list<CSynapseClientSlot>::iterator iSlot );
 
 /*!
    \brief actual implementation of the Resolve function

--- a/libs/synapse/synapse.cpp
+++ b/libs/synapse/synapse.cpp
@@ -126,7 +126,7 @@ bool CSynapseServer::Initialize( const char* conf_file, PFN_SYN_PRINTF_VA pf ){
 		}
 	}
 
-	for ( list<char *>::iterator iPath = mSearchPaths.begin(); iPath != mSearchPaths.end(); iPath++ )
+	for ( std::list<char *>::iterator iPath = mSearchPaths.begin(); iPath != mSearchPaths.end(); iPath++ )
 	{
 		const char* path = *iPath;
 
@@ -290,7 +290,7 @@ PFN_SYN_PRINTF_VA CSynapseServer::Get_Syn_Printf(){
 }
 
 void CSynapseServer::TryPushStack( APIDescriptor_t *pAPI ){
-	list<APIDescriptor_t*>::iterator iAPI;
+	std::list<APIDescriptor_t*>::iterator iAPI;
 	for ( iAPI = mStack.begin(); iAPI != mStack.end(); iAPI++ )
 	{
 		if ( ( *iAPI ) == pAPI ) {
@@ -301,7 +301,7 @@ void CSynapseServer::TryPushStack( APIDescriptor_t *pAPI ){
 	mbStackChanged = true;
 }
 
-list<CSynapseClientSlot>::iterator CSynapseServer::ShutdownClient( list<CSynapseClientSlot>::iterator iSlot ){
+std::list<CSynapseClientSlot>::iterator CSynapseServer::ShutdownClient( std::list<CSynapseClientSlot>::iterator iSlot ){
 	CSynapseClientSlot *pClientSlot = &( *iSlot );
 	if ( pClientSlot->mpClient->IsActive() ) {
 		// this should not happen except during core shutdown (i.e. editor is shutting down)
@@ -314,7 +314,7 @@ list<CSynapseClientSlot>::iterator CSynapseServer::ShutdownClient( list<CSynapse
 	{
 		APIDescriptor_t *pAPI = pClientSlot->mpClient->GetAPIDescriptor( i );
 		// search this API in mStack
-		list< APIDescriptor_t *>::iterator iStack = mStack.begin();
+		std::list< APIDescriptor_t *>::iterator iStack = mStack.begin();
 		while ( iStack != mStack.end() )
 		{
 			if ( *iStack == pAPI ) {
@@ -327,7 +327,7 @@ list<CSynapseClientSlot>::iterator CSynapseServer::ShutdownClient( list<CSynapse
 				if ( pAPI->mbTableInitDone ) {
 					// even if non active, some SYN_REQUIRE may have been filled up
 					// look for the corresponding SYN_PROVIDE and decref
-					list< APIDescriptor_t *>::iterator iStackRequire = mStack.begin();
+					std::list< APIDescriptor_t *>::iterator iStackRequire = mStack.begin();
 					APIDescriptor_t *pMatchAPI;
 					while ( iStackRequire != mStack.end() )
 					{
@@ -400,7 +400,7 @@ void CSynapseServer::PushRequired( CSynapseClient *pClient ){
 	{
 		CSynapseAPIManager *pManager = pClient->GetManagerMatch( i );
 		// start matching all known SYN_PROVIDE APIs against this manager
-		list<CSynapseClientSlot>::iterator iClientSlot;
+		std::list<CSynapseClientSlot>::iterator iClientSlot;
 		for ( iClientSlot = mClients.begin(); iClientSlot != mClients.end(); iClientSlot++ )
 		{
 			CSynapseClient *pScanClient = ( *iClientSlot ).
@@ -428,7 +428,7 @@ void CSynapseServer::PushRequired( CSynapseClient *pClient ){
 int CSynapseServer::FindActiveMajorClient( const char * major, APIDescriptor_t ** ret ) const {
     Syn_Printf( "checking if we have a single active client for major \"%s\"\n", major );
     *ret = NULL;
-    list<CSynapseClientSlot>::const_iterator iClient;
+    std::list<CSynapseClientSlot>::const_iterator iClient;
     for ( iClient = mClients.begin(); iClient != mClients.end(); iClient++ ) {
         CSynapseClient *pClient = ( *iClient ).mpClient;
         if ( !pClient->IsActive() ) {
@@ -507,7 +507,7 @@ int CSynapseServer::MatchAPI( const char* major1, const char* minor1, const char
 bool CSynapseServer::ResolveAPI( APIDescriptor_t* pAPI ){
 	//Syn_Printf("In ResolveAPI %s %p '%s' '%s'\n", APITypeName[pAPI->mType], pAPI, pAPI->major_name, pAPI->minor_name);
 	// loop through active clients, search for a client providing what we are looking for
-	list<CSynapseClientSlot>::iterator iClient;
+	std::list<CSynapseClientSlot>::iterator iClient;
 	for ( iClient = mClients.begin(); iClient != mClients.end(); iClient++ )
 	{
 		// walk through interfaces on this client for a match
@@ -557,7 +557,7 @@ bool CSynapseServer::ResolveAPI( APIDescriptor_t* pAPI ){
 }
 
 bool CSynapseServer::DoResolve( CSynapseClient *pClient ){
-	list<CSynapseClientSlot>::iterator iSlot;
+	std::list<CSynapseClientSlot>::iterator iSlot;
 	for ( iSlot = mClients.begin(); iSlot != mClients.end(); iSlot++ )
 	{
 		if ( ( *iSlot ).mpClient == pClient ) {
@@ -585,7 +585,7 @@ bool CSynapseServer::DoResolve( CSynapseClient *pClient ){
 	// start resolving now
 	// working till the stack is emptied or till we reach a dead end situation
 	// we do a depth first traversal, we will grow the interface stack to be resolved till we start finding solutions
-	list<APIDescriptor_t*>::iterator iCurrent;
+	std::list<APIDescriptor_t*>::iterator iCurrent;
 	mbStackChanged = true; // init to true so we try the first elem
 	while ( !mStack.empty() )
 	{
@@ -619,7 +619,7 @@ bool CSynapseServer::DoResolve( CSynapseClient *pClient ){
 
 bool CSynapseServer::Resolve( CSynapseClient *pClient ){
 	bool ret = DoResolve( pClient );
-	list<CSynapseClientSlot>::iterator iClient;
+	std::list<CSynapseClientSlot>::iterator iClient;
 	iClient = mClients.begin();
 	while ( iClient != mClients.end() )
 	{
@@ -639,7 +639,7 @@ void CSynapseServer::Shutdown(){
 	Syn_Printf( "Synapse server core is shutting down\n" );
 	// do a first pass to shutdown the clients nicely (i.e. decref, release memory and drop everything)
 	// we seperate the client shutdown calls from the dlclose cause that part is a clean decref / free situation whereas dlclose will break links without advice
-	list<CSynapseClientSlot>::iterator iClient;
+	std::list<CSynapseClientSlot>::iterator iClient;
 	iClient = mClients.begin();
 	for ( iClient = mClients.begin(); iClient != mClients.end(); iClient++ )
 	{
@@ -654,7 +654,7 @@ void CSynapseServer::Shutdown(){
 }
 
 void CSynapseServer::DumpStack(){
-	list<APIDescriptor_t*>::iterator iCurrent;
+	std::list<APIDescriptor_t*>::iterator iCurrent;
 	for ( iCurrent = mStack.begin(); iCurrent != mStack.end(); iCurrent++ )
 	{
 		APIDescriptor_t*pAPI = *iCurrent;
@@ -663,7 +663,7 @@ void CSynapseServer::DumpStack(){
 }
 
 void CSynapseServer::DumpActiveClients(){
-	list<CSynapseClientSlot>::iterator iClient;
+	std::list<CSynapseClientSlot>::iterator iClient;
 	for ( iClient = mClients.begin(); iClient != mClients.end(); iClient++ )
 	{
 		CSynapseClient *pClient = ( *iClient ).mpClient;
@@ -757,7 +757,7 @@ bool CSynapseServer::GetConfigForAPI( const char *api, char **minor ) {
 }
 
 const char *CSynapseServer::GetModuleFilename( CSynapseClient *pClient ){
-	list<CSynapseClientSlot>::iterator iSlot;
+	std::list<CSynapseClientSlot>::iterator iSlot;
 	for ( iSlot = mClients.begin(); iSlot != mClients.end(); iSlot++ )
 	{
 		if ( ( *iSlot ).mpClient == pClient ) {
@@ -783,7 +783,7 @@ CSynapseClient::CSynapseClient(){
 }
 
 void CSynapseClient::Shutdown(){
-	vector<APIDescriptor_t *>::iterator iAPI;
+	std::vector<APIDescriptor_t *>::iterator iAPI;
 	for ( iAPI = mAPIDescriptors.begin(); iAPI != mAPIDescriptors.end(); iAPI++ )
 	{
 		APIDescriptor_t *pAPI = *iAPI;
@@ -795,7 +795,7 @@ void CSynapseClient::Shutdown(){
 		*iAPI = NULL;
 	}
 	mAPIDescriptors.clear();
-	vector<CSynapseAPIManager *>::iterator iManager;
+	std::vector<CSynapseAPIManager *>::iterator iManager;
 	for ( iManager = mManagersList.begin(); iManager != mManagersList.end(); iManager++ )
 	{
 		CSynapseAPIManager *pManager = *iManager;
@@ -919,7 +919,7 @@ bool CSynapseClient::CheckSetActive(){
 		}
 	}
 	// if we have managers with fixed list, those need to be completely filled in too
-	vector<CSynapseAPIManager *>::iterator iManager;
+	std::vector<CSynapseAPIManager *>::iterator iManager;
 	for ( iManager = mManagersList.begin(); iManager != mManagersList.end(); iManager++ )
 	{
 		if ( !( *iManager )->CheckSetActive() ) {
@@ -986,7 +986,7 @@ APIDescriptor_t * CSynapseClient::FindProvidesMajor( const char * major ) const 
 }
 
 CSynapseAPIManager::~CSynapseAPIManager(){
-	vector<APIDescriptor_t *>::iterator iAPI;
+	std::vector<APIDescriptor_t *>::iterator iAPI;
 	for ( iAPI = mAPIs.begin(); iAPI != mAPIs.end(); iAPI++ )
 	{
 		APIDescriptor_t *pAPI = *iAPI;
@@ -1033,7 +1033,7 @@ bool CSynapseAPIManager::MatchAPI( const char *major, const char *minor ){
 	/*!
 	   if this interface has been allocated already, avoid requesting it again..
 	 */
-	vector<APIDescriptor_t *>::iterator iAPI;
+	std::vector<APIDescriptor_t *>::iterator iAPI;
 	for ( iAPI = mAPIs.begin(); iAPI != mAPIs.end(); iAPI++ )
 	{
 		if ( CSynapseServer::MatchAPI( ( *iAPI )->major_name, ( *iAPI )->minor_name, major, minor ) ) {

--- a/plugins/model/cpicomodel.cpp
+++ b/plugins/model/cpicomodel.cpp
@@ -148,7 +148,7 @@ void CPicoModel::Reload( void ){
 	}
 }
 
-void CPicoModel::Draw( int state, vector<IShader*> shaders, int rflags ) const {
+void CPicoModel::Draw( int state, std::vector<IShader*> shaders, int rflags ) const {
 	if ( m_pModel ) {
 		for ( unsigned int i = 0; i < m_children->len; i++ )
 			( (CPicoSurface*)m_children->pdata[i] )->Draw( state, shaders[i], rflags );

--- a/plugins/model/cpicomodel.h
+++ b/plugins/model/cpicomodel.h
@@ -36,7 +36,7 @@ virtual void UpdateShaders( void ) = 0;
 class CModelManager;  // forward declaration
 
 //typedef std::pair<Str, int> PicoModelKey;
-typedef pair<Str, int> PicoModelKey;
+typedef std::pair<Str, int> PicoModelKey;
 
 class CPicoModel : public IRender, public ISelect
 {
@@ -63,7 +63,7 @@ void RemoveParent( CPicoParent *parent );
 
 void Reload( void );
 
-void Draw( int state, vector<IShader*> shaders, int rflags ) const;
+void Draw( int state, std::vector<IShader*> shaders, int rflags ) const;
 //IRender
 virtual void Draw( int state, int rflags ) const;
 virtual const bool IsModelNotNull() const { return true; }

--- a/plugins/model/remap.cpp
+++ b/plugins/model/remap.cpp
@@ -75,7 +75,7 @@ typedef CPicoModel value_type;
 public:
 typedef PicoModelKey key_type;
 typedef cache_element<key_type, value_type> elem_type;
-typedef map<key_type, elem_type> cache_type;
+typedef std::map<key_type, elem_type> cache_type;
 
 value_type* capture( const key_type& key ){
 	return m_cache[key].capture( key );
@@ -268,9 +268,9 @@ Str m_name;
 int m_frame;
 CPicoModel* m_model;
 
-typedef vector<remap_t *> remaps_t;
+typedef std::vector<remap_t *> remaps_t;
 remaps_t m_remaps;
-typedef vector<IShader*> shaders_t;
+typedef std::vector<IShader*> shaders_t;
 shaders_t m_shaders;
 };
 

--- a/plugins/surface/surfacedialog.cpp
+++ b/plugins/surface/surfacedialog.cpp
@@ -40,7 +40,7 @@
 
 #include "gtkr_vector.h"
 
-vector<texdef_to_face_t> g_texdef_face_vector;
+std::vector<texdef_to_face_t> g_texdef_face_vector;
 
 inline texdef_to_face_t* get_texdef_face_list(){
 	return &( *g_texdef_face_vector.begin() );

--- a/plugins/surface_idtech2/surfacedialog.cpp
+++ b/plugins/surface_idtech2/surfacedialog.cpp
@@ -36,7 +36,7 @@
 
 #include "gtkr_vector.h"
 
-vector<texdef_to_face_t> g_texdef_face_vector;
+std::vector<texdef_to_face_t> g_texdef_face_vector;
 
 inline texdef_to_face_t* get_texdef_face_list(){
 	return &( *g_texdef_face_vector.begin() );

--- a/radiant/mainframe.cpp
+++ b/radiant/mainframe.cpp
@@ -946,7 +946,7 @@ void MainFrame::process_xlink( Str &FileName, const char *menu_name, const char 
 
 void MainFrame::create_game_help_menu( GtkWidget *menu, GtkAccelGroup *accel ){
 	Str FileName;
-	list<CGameDescription *>::iterator iGame;
+	std::list<CGameDescription *>::iterator iGame;
 
 	// start in the global dir
 	FileName = g_strAppPath;

--- a/radiant/mainframe.h
+++ b/radiant/mainframe.h
@@ -474,7 +474,7 @@ protected:
 /*!
    the urls to fire up in the game packs help menus
  */
-vector<Str *> mHelpURLs;
+std::vector<Str *> mHelpURLs;
 
 /*!
    scan the .game files for game install packs

--- a/radiant/pluginmanager.cpp
+++ b/radiant/pluginmanager.cpp
@@ -126,8 +126,8 @@ private:
 	string_t m_name;
 	string_t m_pattern;
 };
-typedef vector<filetype_copy_t> filetype_list_t;
-map<string_t, filetype_list_t> m_typelists;
+typedef std::vector<filetype_copy_t> filetype_list_t;
+std::map<string_t, filetype_list_t> m_typelists;
 };
 
 static RadiantFileTypeRegistry g_patterns;
@@ -160,7 +160,7 @@ void InitFileTypes(){
 
 class CRadiantModelModuleManager : public CSynapseAPIManager
 {
-typedef list<APIDescriptor_t*> APIDescriptorList;
+typedef std::list<APIDescriptor_t*> APIDescriptorList;
 
 APIDescriptorList mAPIs;
 public:
@@ -317,7 +317,7 @@ IModelCache* GetModelCache(){
 // toolbar manager
 class CRadiantToolbarModuleManager : public CSynapseAPIManager
 {
-typedef list<APIDescriptor_t*> APIDescriptorList;
+typedef std::list<APIDescriptor_t*> APIDescriptorList;
 
 APIDescriptorList mAPIs;
 public:
@@ -370,7 +370,7 @@ CRadiantToolbarModuleManager g_ToolbarModuleManager;
 /* image manager ---------------------------------------- */
 
 CRadiantImageManager::~CRadiantImageManager(){
-	list<CImageTableSlot *>::iterator iSlot;
+	std::list<CImageTableSlot *>::iterator iSlot;
 	for ( iSlot = mSlots.begin(); iSlot != mSlots.end(); iSlot++ )
 	{
 		delete *iSlot;
@@ -412,7 +412,7 @@ void CRadiantImageManager::LoadImage( const char *name, byte **pic, int *width, 
 	if ( ext == NULL ) {
 		// if no extension is provided, start walking through the list
 		Str fullname;
-		list<CImageTableSlot *>::iterator iSlot;
+		std::list<CImageTableSlot *>::iterator iSlot;
 		for ( iSlot = mSlots.begin(); iSlot != mSlots.end(); iSlot++ )
 		{
 			APIDescriptor_t *pAPI = ( *iSlot )->GetDescriptor();
@@ -426,7 +426,7 @@ void CRadiantImageManager::LoadImage( const char *name, byte **pic, int *width, 
 	}
 
 	// start walking the interfaces
-	list<CImageTableSlot *>::iterator iSlot;
+	std::list<CImageTableSlot *>::iterator iSlot;
 	for ( iSlot = mSlots.begin(); iSlot != mSlots.end(); iSlot++ )
 	{
 		APIDescriptor_t *pAPI = ( *iSlot )->GetDescriptor();
@@ -459,7 +459,7 @@ APIDescriptor_t* CRadiantPluginManager::BuildRequireAPI( APIDescriptor_t *pAPI )
 }
 
 void CRadiantPluginManager::PopulateMenu(){
-	list<CPluginSlot *>::iterator iPlug;
+	std::list<CPluginSlot *>::iterator iPlug;
 	for ( iPlug = mSlots.begin(); iPlug != mSlots.end(); iPlug++ )
 	{
 		g_pParentWnd->AddPlugInMenuItem( *iPlug );
@@ -577,7 +577,7 @@ void CPluginSlot::Dispatch( const char *p ){
 }
 
 CRadiantPluginManager::~CRadiantPluginManager(){
-	list<CPluginSlot *>::iterator iSlot;
+	std::list<CPluginSlot *>::iterator iSlot;
 	for ( iSlot = mSlots.begin(); iSlot != mSlots.end(); iSlot++ )
 	{
 		delete *iSlot;
@@ -586,7 +586,7 @@ CRadiantPluginManager::~CRadiantPluginManager(){
 }
 
 bool CRadiantPluginManager::Dispatch( int n, const char* p ){
-	list<CPluginSlot *>::iterator iPlug;
+	std::list<CPluginSlot *>::iterator iPlug;
 	for ( iPlug = mSlots.begin(); iPlug != mSlots.end(); iPlug++ )
 	{
 		CPluginSlot *pPlug = *iPlug;

--- a/radiant/pluginmanager.h
+++ b/radiant/pluginmanager.h
@@ -142,7 +142,7 @@ bool ownsCommandID( int n );
 
 class CRadiantPluginManager : public CSynapseAPIManager
 {
-list<CPluginSlot *> mSlots;
+std::list<CPluginSlot *> mSlots;
 public:
 CRadiantPluginManager() {}
 virtual ~CRadiantPluginManager();
@@ -182,9 +182,9 @@ void InitForFillAPITable( APIDescriptor_t *pAPI );
 
 class CRadiantImageManager : public CSynapseAPIManager
 {
-list<CImageTableSlot *> mSlots;
+std::list<CImageTableSlot *> mSlots;
 
-list<CImageTableSlot *>::iterator mExtScanSlot;
+std::list<CImageTableSlot *>::iterator mExtScanSlot;
 public:
 CRadiantImageManager() {}
 virtual ~CRadiantImageManager();

--- a/radiant/pmesh.cpp
+++ b/radiant/pmesh.cpp
@@ -2900,7 +2900,7 @@ void Patch_TransformLODTexture( patchMesh_t *p, float fx, float fy, transformtyp
 			BTree_TransformTexture( p->colLOD[( ( ( row - 1 ) / 2 ) * p->width ) + col], fx, fy, xform );
 }
 
-void Patch_AddBTreeToDrawListInOrder( list<drawVert_t> *drawList, BTNode_t *pBT ){
+void Patch_AddBTreeToDrawListInOrder( std::list<drawVert_t> *drawList, BTNode_t *pBT ){
 	if ( pBT != NULL ) { //traverse InOrder
 		Patch_AddBTreeToDrawListInOrder( drawList, pBT->left );
 		if ( pBT->left != NULL && pBT->right != NULL ) {
@@ -2910,7 +2910,7 @@ void Patch_AddBTreeToDrawListInOrder( list<drawVert_t> *drawList, BTNode_t *pBT 
 	}
 }
 
-void Patch_InterpolateListFromRowBT( list<drawVert_t> *drawList, BTNode_t *rowBT, BTNode_t *rowBTLeft, drawVert_t *vCurve[], float u, float n, float v ){
+void Patch_InterpolateListFromRowBT( std::list<drawVert_t> *drawList, BTNode_t *rowBT, BTNode_t *rowBTLeft, drawVert_t *vCurve[], float u, float n, float v ){
 	if ( rowBT != NULL ) {
 		Patch_InterpolateListFromRowBT( drawList, rowBT->left, rowBTLeft->left, vCurve, u - n, n * 0.5f, v );
 		if ( rowBT->left != NULL && rowBT->right != NULL ) {
@@ -2934,7 +2934,7 @@ void Patch_InterpolateListFromRowBT( list<drawVert_t> *drawList, BTNode_t *rowBT
 	}
 }
 
-void Patch_TraverseColBTInOrder( list<list<drawVert_t>*>::iterator& iter, BTNode_t *colBTLeft, BTNode_t *colBT, BTNode_t *colBTRight, BTNode_t *rowBT, BTNode_t *rowBTLeft, float v, float n ){
+void Patch_TraverseColBTInOrder( std::list<std::list<drawVert_t>*>::iterator& iter, BTNode_t *colBTLeft, BTNode_t *colBT, BTNode_t *colBTRight, BTNode_t *rowBT, BTNode_t *rowBTLeft, float v, float n ){
 	if ( colBT != NULL ) {
 		//traverse subtree In Order
 		Patch_TraverseColBTInOrder( iter, colBTLeft->left, colBT->left, colBTRight->left, rowBT, rowBTLeft, v - n, n * 0.5f );
@@ -2953,12 +2953,12 @@ void Patch_TraverseColBTInOrder( list<list<drawVert_t>*>::iterator& iter, BTNode
 }
 
 
-void Patch_StartDrawLists( list<list<drawVert_t>*> *drawLists, BTNode_t *colBT ){
+void Patch_StartDrawLists( std::list<std::list<drawVert_t>*> *drawLists, BTNode_t *colBT ){
 	if ( colBT != NULL ) {
 		//traverse subtree In Order
 		Patch_StartDrawLists( drawLists, colBT->left );
 		if ( colBT->left != NULL && colBT->right != NULL ) {
-			list<drawVert_t> *newList = new list<drawVert_t>;
+			std::list<drawVert_t> *newList = new std::list<drawVert_t>;
 			drawLists->push_back( newList ); // add empty list to back
 			drawLists->back()->push_back( colBT->vMid );
 		}
@@ -2966,8 +2966,8 @@ void Patch_StartDrawLists( list<list<drawVert_t>*> *drawLists, BTNode_t *colBT )
 	}
 }
 
-typedef list<drawVert_t> drawList_t;
-typedef list<list<drawVert_t>*> drawLists_t;
+typedef std::list<drawVert_t> drawList_t;
+typedef std::list<std::list<drawVert_t>*> drawLists_t;
 
 void Patch_CreateDrawLists( patchMesh_t *patch ){
 	int col, row, colpos, rowpos;

--- a/radiant/preferences.cpp
+++ b/radiant/preferences.cpp
@@ -247,7 +247,7 @@ CXMLPropertyBag::CXMLPropertyBag() {
 // generic preference functions
 
 void CXMLPropertyBag::PushAssignment( const char *name, PrefTypes_t type, void *pV ){
-	list<CPrefAssignment>::iterator iAssign;
+	std::list<CPrefAssignment>::iterator iAssign;
 	for ( iAssign = mPrefAssignments.begin(); iAssign != mPrefAssignments.end(); iAssign++ )
 	{
 		if ( ( *iAssign ).mName == name ) {
@@ -399,7 +399,7 @@ void CXMLPropertyBag::GetPref( const char *name, window_position_t* pV, window_p
 
 void CXMLPropertyBag::UpdatePrefTree(){
 	// read the assignments and update the tree
-	list<CPrefAssignment>::iterator iPref;
+	std::list<CPrefAssignment>::iterator iPref;
 	for ( iPref = mPrefAssignments.begin(); iPref != mPrefAssignments.end(); iPref++ )
 	{
 		CPrefAssignment *pPref = &( *iPref );
@@ -1097,7 +1097,7 @@ GtkWidget* CGameDialog::GetGlobalFrame(){
 void CGameDialog::UpdateData( bool retrieve ) {
 	if ( !retrieve ) {
 		// use m_sGameFile to set m_nComboSelect
-		list<CGameDescription *>::iterator iGame;
+		std::list<CGameDescription *>::iterator iGame;
 		int i = 0;
 		for ( iGame = mGames.begin(); iGame != mGames.end(); iGame++ )
 		{
@@ -1114,7 +1114,7 @@ void CGameDialog::UpdateData( bool retrieve ) {
 	Dialog::UpdateData( retrieve );
 	if ( retrieve ) {
 		// use m_nComboSelect to set m_sGameFile
-		list<CGameDescription *>::iterator iGame = mGames.begin();
+		std::list<CGameDescription *>::iterator iGame = mGames.begin();
 		int i;
 		for ( i = 0; i < m_nComboSelect; i++ )
 		{
@@ -1168,7 +1168,7 @@ void CGameDialog::BuildDialog() {
 
 void CGameDialog::UpdateGameCombo() {
 	// fill in with the game descriptions
-	list<CGameDescription *>::iterator iGame;
+	std::list<CGameDescription *>::iterator iGame;
 	GtkListStore *store;
 
 	if ( mGameCombo == NULL ) {
@@ -1199,7 +1199,7 @@ void CGameDialog::ScanForGames(){
 
 	if ( !mGames.empty() ) {
 		Sys_Printf( "Clearing game list\n" );
-		list<CGameDescription*>::iterator iGame;
+		std::list<CGameDescription*>::iterator iGame;
 		for ( iGame = mGames.begin(); iGame != mGames.end(); iGame++ ) {
 			delete ( *iGame );
 		}
@@ -1259,7 +1259,7 @@ void CGameDialog::ScanForGames(){
 }
 
 CGameDescription* CGameDialog::GameDescriptionForComboItem(){
-	list<CGameDescription *>::iterator iGame;
+	std::list<CGameDescription *>::iterator iGame;
 	int i = 0;
 	for ( iGame = mGames.begin(); iGame != mGames.end(); iGame++,i++ ) {
 		if ( i == m_nComboSelect ) {
@@ -1299,7 +1299,7 @@ void CGameDialog::Init(){
 	LoadPrefs();
 	if ( m_bAutoLoadGame ) {
 		// search by .game name
-		list<CGameDescription *>::iterator iGame;
+		std::list<CGameDescription *>::iterator iGame;
 		for ( iGame = mGames.begin(); iGame != mGames.end(); iGame++ )
 		{
 			if ( ( *iGame )->mGameFile == m_sGameFile ) {
@@ -1347,7 +1347,7 @@ CGameDialog::~CGameDialog(){
 		g_object_unref( GTK_WIDGET( mFrame ) );
 	}
 	// free all the game descriptions
-	list<CGameDescription *>::iterator iGame;
+	std::list<CGameDescription *>::iterator iGame;
 	for ( iGame = mGames.begin(); iGame != mGames.end(); iGame++ )
 	{
 		delete ( *iGame );
@@ -1358,7 +1358,7 @@ CGameDialog::~CGameDialog(){
 void CGameDialog::AddPacksURL( Str &URL ){
 	// add the URLs for the list of game packs installed
 	// FIXME: this is kinda hardcoded for now..
-	list<CGameDescription *>::iterator iGame;
+	std::list<CGameDescription *>::iterator iGame;
 	for ( iGame = mGames.begin(); iGame != mGames.end(); iGame++ )
 	{
 		if ( ( *iGame )->mGameFile == "q3.game" ) {

--- a/radiant/preferences.h
+++ b/radiant/preferences.h
@@ -79,7 +79,7 @@ xmlNodePtr mpDocNode;
 /*!
    prefs assignments (what pref name, what type, what variable)
  */
-list<CPrefAssignment> mPrefAssignments;
+std::list<CPrefAssignment> mPrefAssignments;
 
 /*!
    name of file to load/save as
@@ -348,7 +348,7 @@ CGameDescription *m_pCurrentGameDescription;
 /*!
    the list of game descriptions we scanned from the game/ dir
  */
-list<CGameDescription *> mGames;
+std::list<CGameDescription *> mGames;
 
 CGameDialog() {
 	mFrame = NULL;
@@ -499,7 +499,7 @@ CGameDialog mGamesDialog;
 protected:
 // warning about old project files
 bool m_bWarn;
-list<CGameDescription *> mGames;
+std::list<CGameDescription *> mGames;
 
 public:
 // last light intensity used in the CLightPrompt dialog, stored in registry


### PR DESCRIPTION
The STL now defines `std::byte` so doing `using namespace std` will conflict will custom definition of `byte`, which this legacy code is full of.

It looks like NetRadiant went the route of making explicit usage of `std::` prefixed types and did not renamed the custom definition of byte, so doing the same reduces diff noise between the two trees.

This also makes the code future proof if the STL decides to define some other types with common name.

This patches replaces all usages of `map`, `pair` and `vector` with `std::map`, `std::pair` and `std::vector` and removes the `using namespace std` line in `stl_check.h`.

```
libs/mathlib.h:132:44: error: reference to ‘byte’ is ambiguous
  132 | void NormalToLatLong( const vec3_t normal, byte bytes[2] );
      |                                            ^~~~
In file included from /usr/include/c++/11/bits/stl_algobase.h:61,
                 from /usr/include/c++/11/bits/char_traits.h:39,
                 from /usr/include/c++/11/ios:40,
                 from /usr/include/c++/11/ostream:38,
                 from /usr/include/c++/11/iostream:39,
                 from libs/missing.h:76,
                 from radiant/qe3.h:40,
                 from radiant/stdafx.h:39,
                 from radiant/bp_dlg.cpp:28:
/usr/include/c++/11/bits/cpp_type_traits.h:404:30: note: candidates are: ‘enum class std::byte’
  404 |   enum class byte : unsigned char;
      |                              ^~~~
```