### PR TITLE
error: ‘nullptr’ was not declared in this scope #693

### DIFF
--- a/config.py
+++ b/config.py
@@ -257,7 +257,7 @@ class Config:
                 env.ParseConfig( 'pkg-config zlib --cflags --libs' )
 
         env.Append( CCFLAGS = baseflags )
-        env.Append( CXXFLAGS = baseflags + [ '-fpermissive', '-fvisibility-inlines-hidden' ] )
+        env.Append( CXXFLAGS = baseflags + [ '-fpermissive', '-fvisibility-inlines-hidden', '-std=c++11' ] )
         env.Append( CPPPATH = [ 'include', 'libs' ] )
         env.Append( CPPDEFINES = [ 'Q_NO_STLPORT' ] )
         if ( config == 'debug' ):


### PR DESCRIPTION
adding '-std=c++11' flag to prevent the classic "‘nullptr’ was not declared in this scope" error (@nuxy came to the same solution)